### PR TITLE
Fix release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ deploy:
   - provider: releases
     api_key: "${GH_TOKEN}"
     file_glob: true
-    file: "./target/recheck-cli-*-bin.zip"
+    file: "./target/recheck.cli-*-bin.zip"
     skip_cleanup: true
     draft: true
     on:

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Commands:
 You can download the most recent version from the [GitHub releases page](https://github.com/retest/recheck.cli/releases/). Afterwards, you have to include the CLI into your path to use it from your shell. On Unix-like systems, you can do this by adding the following snippet to your `.bash_profile` and/or `.bashrc`:
 
 ```
-export PATH="${PATH}:/path/to/recheck-cli/bin/"
+export PATH="${PATH}:/path/to/recheck.cli/bin/"
 ```
 
-On Windows, you can add `/path/to/recheck-cli/bin/` to your path by following [this tutorial](https://java.com/en/download/help/path.xml).
+On Windows, you can add `/path/to/recheck.cli/bin/` to your path by following [this tutorial](https://java.com/en/download/help/path.xml).
 
 ## Enabling Shell Auto-Completion
 

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
 				<version>3.1.1</version>
 				<executions>
 					<execution>
-						<id>create-recheck-cli</id>
+						<id>create-recheck.cli</id>
 						<phase>package</phase>
 						<goals>
 							<goal>single</goal>
@@ -221,7 +221,7 @@
 							<descriptorRefs>
 								<descriptorRef>jar-with-dependencies</descriptorRef>
 							</descriptorRefs>
-							<finalName>recheck-cli</finalName>
+							<finalName>recheck.cli</finalName>
 							<appendAssemblyId>false</appendAssemblyId>
 							<archive>
 								<manifest>

--- a/src/main/package/bin/recheck
+++ b/src/main/package/bin/recheck
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o nounset -o errexit -o pipefail
 
-# recheck installation directory.
+# recheck.cli installation directory.
 RECHECK_HOME="$( ( cd "$( dirname "$0" )" && pwd -P ) )/.."
 
 JAVA="java"
@@ -9,4 +9,4 @@ JAVA="java"
 JAVA_ARGS=(-XX:+HeapDumpOnOutOfMemoryError)
 JAVA_ARGS+=(-XX:-OmitStackTraceInFastThrow)
 
-exec $JAVA "${JAVA_ARGS[@]}" -jar "$RECHECK_HOME/lib/recheck-cli.jar" "$@" 2>&1
+exec $JAVA "${JAVA_ARGS[@]}" -jar "$RECHECK_HOME/lib/recheck.cli.jar" "$@" 2>&1

--- a/src/main/package/bin/recheck.cmd
+++ b/src/main/package/bin/recheck.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-:: recheck-cli installation directory.
+:: recheck.cli installation directory.
 SET RECHECK_HOME=%~dp0\..
 
 SET JAVA=java
@@ -8,4 +8,4 @@ SET JAVA=java
 SET JAVA_ARGS=-XX:+HeapDumpOnOutOfMemoryError
 SET JAVA_ARGS=%JAVA_ARGS% -XX:-OmitStackTraceInFastThrow
 
-%JAVA% %JAVA_ARGS% -jar "%RECHECK_HOME%\lib\recheck-cli.jar" %* 2>&1
+%JAVA% %JAVA_ARGS% -jar "%RECHECK_HOME%\lib\recheck.cli.jar" %* 2>&1


### PR DESCRIPTION
Travis didn't upload the ZIP file because we were still using "recheck-cli" in the Travis config, although the assembly name was derived from the project. I though it's easier to simply change everything to "recheck.cli" (I've also added the release ZIP to v0.4.0 manually).