### PR TITLE
Improve report handling

### DIFF
--- a/src/main/java/de/retest/recheck/cli/RecheckCli.java
+++ b/src/main/java/de/retest/recheck/cli/RecheckCli.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.cli;
 
+import de.retest.recheck.Properties;
 import de.retest.recheck.cli.subcommands.Commit;
 import de.retest.recheck.cli.subcommands.Completion;
 import de.retest.recheck.cli.subcommands.Diff;
@@ -14,9 +15,10 @@ import picocli.CommandLine.Option;
 		subcommands = { Version.class, Diff.class, Commit.class, Ignore.class, Completion.class, CommandLine.HelpCommand.class } )
 public class RecheckCli implements Runnable {
 
-	public static final String REPORT_FILE_PARAM_DESCRIPTION = "Path to a test report file." //
-			+ " If the test report is not in the project directory, please specify the" //
-			+ " absolute path, otherwise a relative path is sufficient.";
+	public static final String REPORT_FILE_PARAM_DESCRIPTION =
+			"Path to a test report file (" + Properties.TEST_REPORT_FILE_EXTENSION + " extension). " //
+					+ "If the test report is not in the project directory, please specify the absolute path, " //
+					+ "otherwise a relative path is sufficient.";
 
 	@Option( names = "--help", usageHelp = true, description = "Display this help message." )
 	private boolean displayHelp;

--- a/src/main/java/de/retest/recheck/cli/RecheckCli.java
+++ b/src/main/java/de/retest/recheck/cli/RecheckCli.java
@@ -1,6 +1,5 @@
 package de.retest.recheck.cli;
 
-import de.retest.recheck.Properties;
 import de.retest.recheck.cli.subcommands.Commit;
 import de.retest.recheck.cli.subcommands.Completion;
 import de.retest.recheck.cli.subcommands.Diff;
@@ -11,14 +10,9 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 @Command( name = "recheck", description = "Command-line interface for recheck.",
-		versionProvider = VersionProvider.class,
-		subcommands = { Version.class, Diff.class, Commit.class, Ignore.class, Completion.class, CommandLine.HelpCommand.class } )
+		versionProvider = VersionProvider.class, subcommands = { Version.class, Diff.class, Commit.class, Ignore.class,
+				Completion.class, CommandLine.HelpCommand.class } )
 public class RecheckCli implements Runnable {
-
-	public static final String REPORT_FILE_PARAM_DESCRIPTION =
-			"Path to a test report file (" + Properties.TEST_REPORT_FILE_EXTENSION + " extension). " //
-					+ "If the test report is not in the project directory, please specify the absolute path, " //
-					+ "otherwise a relative path is sufficient.";
 
 	@Option( names = "--help", usageHelp = true, description = "Display this help message." )
 	private boolean displayHelp;

--- a/src/main/java/de/retest/recheck/cli/TestReportFormatException.java
+++ b/src/main/java/de/retest/recheck/cli/TestReportFormatException.java
@@ -1,0 +1,9 @@
+package de.retest.recheck.cli;
+
+import java.io.IOException;
+
+public class TestReportFormatException extends IOException {
+
+	private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/de/retest/recheck/cli/TestReportFormatException.java
+++ b/src/main/java/de/retest/recheck/cli/TestReportFormatException.java
@@ -1,8 +1,6 @@
 package de.retest.recheck.cli;
 
-import java.io.IOException;
-
-public class TestReportFormatException extends IOException {
+public class TestReportFormatException extends Exception {
 
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/de/retest/recheck/cli/TestReportUtil.java
+++ b/src/main/java/de/retest/recheck/cli/TestReportUtil.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.retest.recheck.Properties;
 import de.retest.recheck.persistence.Persistence;
 import de.retest.recheck.persistence.bin.KryoPersistence;
 import de.retest.recheck.report.TestReport;
@@ -16,10 +17,17 @@ public class TestReportUtil {
 
 	private TestReportUtil() {}
 
-	public static TestReport load( final File testReportFile ) throws IOException {
+	public static TestReport load( final File testReportFile ) throws TestReportFormatException, IOException {
 		logger.info( "Checking test report in path '{}'.", testReportFile.getPath() );
+		checkExtension( testReportFile );
 		final Persistence<TestReport> persistence = new KryoPersistence<>();
 		return persistence.load( testReportFile.toURI() );
+	}
+
+	private static void checkExtension( final File testReportFile ) throws TestReportFormatException {
+		if ( !testReportFile.getName().endsWith( Properties.TEST_REPORT_FILE_EXTENSION ) ) {
+			throw new TestReportFormatException();
+		}
 	}
 
 	public static void print( final TestReport testReport, final File testReportFile ) {

--- a/src/main/java/de/retest/recheck/cli/TestReportUtil.java
+++ b/src/main/java/de/retest/recheck/cli/TestReportUtil.java
@@ -15,6 +15,11 @@ public class TestReportUtil {
 
 	private static final Logger logger = LoggerFactory.getLogger( TestReportUtil.class );
 
+	public static final String TEST_REPORT_PARAMETER_DESCRIPTION =
+			"Path to a test report file (" + Properties.TEST_REPORT_FILE_EXTENSION + " extension). " //
+					+ "If the test report is not in the project directory, please specify the absolute path, " //
+					+ "otherwise a relative path is sufficient.";
+
 	private TestReportUtil() {}
 
 	public static TestReport load( final File testReportFile ) throws TestReportFormatException, IOException {

--- a/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
@@ -11,9 +11,11 @@ import org.slf4j.LoggerFactory;
 
 import com.esotericsoftware.kryo.KryoException;
 
+import de.retest.recheck.Properties;
 import de.retest.recheck.cli.FilterUtil;
 import de.retest.recheck.cli.PreCondition;
 import de.retest.recheck.cli.RecheckCli;
+import de.retest.recheck.cli.TestReportFormatException;
 import de.retest.recheck.cli.TestReportUtil;
 import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.persistence.NoGoldenMasterFoundException;
@@ -69,6 +71,9 @@ public class Commit implements Runnable {
 			for ( final SuiteChangeSet suiteChangeSet : reviewResult.getSuiteChangeSets() ) {
 				applyChanges( createSutStatePersistence(), suiteChangeSet );
 			}
+		} catch ( final TestReportFormatException e ) {
+			logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
+					Properties.TEST_REPORT_FILE_EXTENSION );
 		} catch ( final IOException e ) {
 			logger.error( "An error occurred while loading the test report!", e );
 		} catch ( final KryoException e ) {

--- a/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
@@ -75,11 +75,11 @@ public class Commit implements Runnable {
 			logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
 					Properties.TEST_REPORT_FILE_EXTENSION );
 		} catch ( final IOException e ) {
-			logger.error( "An error occurred while loading the test report!", e );
+			logger.error( "An error occurred while loading the test report.", e );
 		} catch ( final KryoException e ) {
-			logger.error( "The report was created with another, incompatible recheck version.\r\n"
-					+ "Please, use the same recheck version to load a report with which it was generated." );
-			logger.debug( "StackTrace: ", e );
+			logger.error( "The report was created with another, incompatible recheck version.\n"
+					+ "Please use the same recheck version to load a report with which it was generated." );
+			logger.debug( "Stack trace:", e );
 		}
 	}
 

--- a/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
@@ -14,7 +14,6 @@ import com.esotericsoftware.kryo.KryoException;
 import de.retest.recheck.Properties;
 import de.retest.recheck.cli.FilterUtil;
 import de.retest.recheck.cli.PreCondition;
-import de.retest.recheck.cli.RecheckCli;
 import de.retest.recheck.cli.TestReportFormatException;
 import de.retest.recheck.cli.TestReportUtil;
 import de.retest.recheck.ignore.Filter;
@@ -47,7 +46,7 @@ public class Commit implements Runnable {
 	@Option( names = "--exclude", description = "Filter(s) to exclude changes from the diff." )
 	private List<String> exclude;
 
-	@Parameters( arity = "1", description = RecheckCli.REPORT_FILE_PARAM_DESCRIPTION )
+	@Parameters( arity = "1", description = TestReportUtil.TEST_REPORT_PARAMETER_DESCRIPTION )
 	private File testReport;
 
 	@Override

--- a/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
@@ -55,11 +55,11 @@ public class Diff implements Runnable {
 			logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
 					Properties.TEST_REPORT_FILE_EXTENSION );
 		} catch ( final IOException e ) {
-			logger.error( "Differences couldn't be printed:", e );
+			logger.error( "An error occurred while loading the test report.", e );
 		} catch ( final KryoException e ) {
-			logger.error( "The report was created with another, incompatible recheck version.\r\n"
-					+ "Please, use the same recheck version to load a report with which it was generated." );
-			logger.debug( "StackTrace: ", e );
+			logger.error( "The report was created with another, incompatible recheck version.\n"
+					+ "Please use the same recheck version to load a report with which it was generated." );
+			logger.debug( "Stack trace:", e );
 		}
 	}
 

--- a/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
@@ -12,9 +12,11 @@ import org.slf4j.LoggerFactory;
 
 import com.esotericsoftware.kryo.KryoException;
 
+import de.retest.recheck.Properties;
 import de.retest.recheck.cli.FilterUtil;
 import de.retest.recheck.cli.PreCondition;
 import de.retest.recheck.cli.RecheckCli;
+import de.retest.recheck.cli.TestReportFormatException;
 import de.retest.recheck.cli.TestReportUtil;
 import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.printer.TestReportPrinter;
@@ -49,6 +51,9 @@ public class Diff implements Runnable {
 			final TestReport filteredTestReport = TestReportFilter.filter( report, excludeFilter );
 			final TestReportPrinter printer = new TestReportPrinter( none(), loadRecheckIgnore() );
 			logger.info( "\n{}", printer.toString( filteredTestReport ) );
+		} catch ( final TestReportFormatException e ) {
+			logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
+					Properties.TEST_REPORT_FILE_EXTENSION );
 		} catch ( final IOException e ) {
 			logger.error( "Differences couldn't be printed:", e );
 		} catch ( final KryoException e ) {

--- a/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
@@ -15,7 +15,6 @@ import com.esotericsoftware.kryo.KryoException;
 import de.retest.recheck.Properties;
 import de.retest.recheck.cli.FilterUtil;
 import de.retest.recheck.cli.PreCondition;
-import de.retest.recheck.cli.RecheckCli;
 import de.retest.recheck.cli.TestReportFormatException;
 import de.retest.recheck.cli.TestReportUtil;
 import de.retest.recheck.ignore.Filter;
@@ -37,7 +36,7 @@ public class Diff implements Runnable {
 	@Option( names = "--exclude", description = "Filter(s) to exclude changes from the diff." )
 	private List<String> exclude;
 
-	@Parameters( arity = "1", description = RecheckCli.REPORT_FILE_PARAM_DESCRIPTION )
+	@Parameters( arity = "1", description = TestReportUtil.TEST_REPORT_PARAMETER_DESCRIPTION )
 	private File testReport;
 
 	@Override

--- a/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
@@ -89,11 +89,11 @@ public class Ignore implements Runnable {
 				logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
 						Properties.TEST_REPORT_FILE_EXTENSION );
 			} catch ( final IOException e ) {
-				logger.error( "An error occurred while loading the test report!", e );
+				logger.error( "An error occurred while loading the test report.", e );
 			} catch ( final KryoException e ) {
-				logger.error( "The report was created with another, incompatible recheck version.\r\n"
-						+ "Please, use the same recheck version to load a report with which it was generated." );
-				logger.debug( "StackTrace: ", e );
+				logger.error( "The report was created with another, incompatible recheck version.\n"
+						+ "Please use the same recheck version to load a report with which it was generated." );
+				logger.debug( "Stack trace:", e );
 			}
 		}
 	}

--- a/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
@@ -11,8 +11,10 @@ import org.slf4j.LoggerFactory;
 
 import com.esotericsoftware.kryo.KryoException;
 
+import de.retest.recheck.Properties;
 import de.retest.recheck.cli.PreCondition;
 import de.retest.recheck.cli.RecheckCli;
+import de.retest.recheck.cli.TestReportFormatException;
 import de.retest.recheck.cli.TestReportUtil;
 import de.retest.recheck.ignore.RecheckIgnoreUtil;
 import de.retest.recheck.report.ActionReplayResult;
@@ -83,6 +85,9 @@ public class Ignore implements Runnable {
 					return;
 				}
 				saveRecheckIgnore();
+			} catch ( final TestReportFormatException e ) {
+				logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
+						Properties.TEST_REPORT_FILE_EXTENSION );
 			} catch ( final IOException e ) {
 				logger.error( "An error occurred while loading the test report!", e );
 			} catch ( final KryoException e ) {

--- a/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
@@ -13,7 +13,6 @@ import com.esotericsoftware.kryo.KryoException;
 
 import de.retest.recheck.Properties;
 import de.retest.recheck.cli.PreCondition;
-import de.retest.recheck.cli.RecheckCli;
 import de.retest.recheck.cli.TestReportFormatException;
 import de.retest.recheck.cli.TestReportUtil;
 import de.retest.recheck.ignore.RecheckIgnoreUtil;
@@ -46,7 +45,7 @@ public class Ignore implements Runnable {
 	@Option( names = "--list", description = "List all ignored elements." )
 	private boolean list;
 
-	@Parameters( arity = "0..1", description = RecheckCli.REPORT_FILE_PARAM_DESCRIPTION )
+	@Parameters( arity = "0..1", description = TestReportUtil.TEST_REPORT_PARAMETER_DESCRIPTION )
 	private File testReport;
 
 	private GlobalIgnoreApplier ignoreApplier;

--- a/src/test/java/de/retest/recheck/cli/TestReportUtilTest.java
+++ b/src/test/java/de/retest/recheck/cli/TestReportUtilTest.java
@@ -1,0 +1,40 @@
+package de.retest.recheck.cli;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import de.retest.recheck.Properties;
+import de.retest.recheck.cli.util.TestReportCreator;
+
+public class TestReportUtilTest {
+
+	@Rule
+	public TemporaryFolder temp = new TemporaryFolder();
+
+	@Test
+	public void should_load_test_report() throws Exception {
+		final File testReportFile = new File( TestReportCreator.createTestReportFileWithoutDiffs( temp ) );
+		TestReportUtil.load( testReportFile );
+	}
+
+	@Test
+	public void should_throw_exception_in_case_of_wrong_test_report_format() throws Exception {
+		final File stateXml = temp.newFile( Properties.DEFAULT_XML_FILE_NAME );
+		assertThatThrownBy( () -> TestReportUtil.load( stateXml ) )
+				.isExactlyInstanceOf( TestReportFormatException.class );
+
+		final File emptyFile = temp.newFile();
+		assertThatThrownBy( () -> TestReportUtil.load( emptyFile ) )
+				.isExactlyInstanceOf( TestReportFormatException.class );
+
+		final File emptyFolder = temp.newFolder();
+		assertThatThrownBy( () -> TestReportUtil.load( emptyFolder ) )
+				.isExactlyInstanceOf( TestReportFormatException.class );
+	}
+
+}

--- a/src/test/java/de/retest/recheck/cli/TestReportUtilTest.java
+++ b/src/test/java/de/retest/recheck/cli/TestReportUtilTest.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.cli;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
@@ -19,7 +20,7 @@ public class TestReportUtilTest {
 	@Test
 	public void should_load_test_report() throws Exception {
 		final File testReportFile = new File( TestReportCreator.createTestReportFileWithoutDiffs( temp ) );
-		TestReportUtil.load( testReportFile );
+		assertThatCode( () -> TestReportUtil.load( testReportFile ) ).doesNotThrowAnyException();
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/cli/subcommands/CommitIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/CommitIT.java
@@ -29,9 +29,10 @@ public class CommitIT {
 	public void commit_without_argument_should_return_the_usage_message() {
 		final String expectedMessage = "Usage: commit [--all] [--exclude=<exclude>]... <testReport>\n"
 				+ "Accept specified differences of given test report.\n"
-				+ "      <testReport>          Path to a test report file. If the test report is not in\n"
-				+ "                              the project directory, please specify the absolute\n"
-				+ "                              path, otherwise a relative path is sufficient.\n"
+				+ "      <testReport>          Path to a test report file (.report extension). If the\n"
+				+ "                              test report is not in the project directory, please\n"
+				+ "                              specify the absolute path, otherwise a relative path\n"
+				+ "                              is sufficient."
 				+ "      --all                 Accept all differences from the given test report.\n"
 				+ "      --exclude=<exclude>   Filter(s) to exclude changes from the diff.\n";
 		assertThat( new CommandLine( new Commit() ).getUsageMessage() ).isEqualToIgnoringNewLines( expectedMessage );

--- a/src/test/java/de/retest/recheck/cli/subcommands/CommitIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/CommitIT.java
@@ -91,4 +91,17 @@ public class CommitIT {
 				+ "' is within the corresponding project directory.\n";
 		assertThat( systemOutRule.getLog() ).contains( expectedMessage );
 	}
+
+	@Test
+	public void commit_should_give_proper_error_message_when_given_test_report_is_not_a_test_report() throws Exception {
+		final File notATestReport = temp.newFile();
+		final String[] args = { "--all", notATestReport.getAbsolutePath() };
+		final Commit cut = new Commit();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() ).contains(
+				"The given file is not a test report. Please only pass files using the '.report' extension." );
+	}
 }

--- a/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
@@ -30,9 +30,10 @@ public class DiffIT {
 	public void diff_without_argument_should_return_the_usage_message() {
 		final String expected =
 				"Usage: diff [--exclude=<exclude>]... <testReport>\n" + "Display differences of given test report.\n"
-						+ "      <testReport>          Path to a test report file. If the test report is not in\n"
-						+ "                              the project directory, please specify the absolute\n"
-						+ "                              path, otherwise a relative path is sufficient.\n"
+						+ "      <testReport>          Path to a test report file (.report extension). If the\n"
+						+ "                              test report is not in the project directory, please\n"
+						+ "                              specify the absolute path, otherwise a relative path\n"
+						+ "                              is sufficient."
 						+ "      --exclude=<exclude>   Filter(s) to exclude changes from the diff.\n";
 		assertThat( new CommandLine( new Diff() ).getUsageMessage() ).isEqualToIgnoringNewLines( expected );
 	}

--- a/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
@@ -64,4 +64,17 @@ public class DiffIT {
 
 		assertThat( systemOutRule.getLog() ).contains( expected );
 	}
+
+	@Test
+	public void diff_should_give_proper_error_message_when_given_test_report_is_not_a_test_report() throws Exception {
+		final File notATestReport = temp.newFile();
+		final String[] args = { notATestReport.getAbsolutePath() };
+		final Diff cut = new Diff();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() ).contains(
+				"The given file is not a test report. Please only pass files using the '.report' extension." );
+	}
 }

--- a/src/test/java/de/retest/recheck/cli/subcommands/IgnoreIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/IgnoreIT.java
@@ -28,9 +28,9 @@ public class IgnoreIT {
 	public void ignore_without_argument_should_return_the_usage_message() {
 		final String expected = "Usage: ignore [--all] [--list] [<testReport>]\n"
 				+ "Ignore specified differences of given test report.\n"
-				+ "      [<testReport>]   Path to a test report file. If the test report is not in the\n"
-				+ "                         project directory, please specify the absolute path,\n"
-				+ "                         otherwise a relative path is sufficient.\n"
+				+ "      [<testReport>]   Path to a test report file (.report extension). If the test\n"
+				+ "                         report is not in the project directory, please specify the\n"
+				+ "                         absolute path, otherwise a relative path is sufficient.\n"
 				+ "      --all            Ignore all differences from the given test report.\n"
 				+ "      --list           List all ignored elements.\n";
 		assertThat( new CommandLine( new Ignore() ).getUsageMessage() ).isEqualTo( expected );

--- a/src/test/java/de/retest/recheck/cli/subcommands/IgnoreIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/IgnoreIT.java
@@ -3,6 +3,8 @@ package de.retest.recheck.cli.subcommands;
 import static de.retest.recheck.cli.util.ProjectRootFaker.fakeProjectRoot;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
@@ -105,5 +107,18 @@ public class IgnoreIT {
 		cut.run();
 
 		assertThat( systemOutRule.getLog() ).contains( expected );
+	}
+
+	@Test
+	public void ignore_should_give_proper_error_message_when_given_test_report_is_not_a_test_report() throws Exception {
+		final File notATestReport = temp.newFile();
+		final String[] args = { "--all", notATestReport.getAbsolutePath() };
+		final Ignore cut = new Ignore();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() ).contains(
+				"The given file is not a test report. Please only pass files using the '.report' extension." );
 	}
 }


### PR DESCRIPTION
When a user passes e.g. a state XML instead of a test report, he gets the same generic Kryo error message, although he did use the wrong file in the first place (see https://github.com/retest/recheck/issues/315).