### PR TITLE
Improve error messages for non-existing files

### DIFF
--- a/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
@@ -1,8 +1,6 @@
 package de.retest.recheck.cli.subcommands;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -10,11 +8,8 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.esotericsoftware.kryo.KryoException;
-
-import de.retest.recheck.Properties;
 import de.retest.recheck.cli.PreCondition;
-import de.retest.recheck.cli.TestReportFormatException;
+import de.retest.recheck.cli.utils.ErrorHandler;
 import de.retest.recheck.cli.utils.FilterUtil;
 import de.retest.recheck.cli.utils.SystemInUtil;
 import de.retest.recheck.cli.utils.TestReportUtil;
@@ -76,19 +71,8 @@ public class Commit implements Runnable {
 				final ReviewResult reviewResult = CreateChangesetForAllDifferencesFlow.create( filteredTestReport );
 				checkForWarningAndApplyChanges( reviewResult );
 			}
-		} catch ( final TestReportFormatException e ) {
-			logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
-					Properties.TEST_REPORT_FILE_EXTENSION );
-		} catch ( final NoSuchFileException e ) {
-			logger.error( "The given file report '{}' does not exist. Please check the given file path.",
-					testReport.getAbsolutePath() );
-			logger.debug( "Stack trace:", e );
-		} catch ( final IOException e ) {
-			logger.error( "An error occurred while loading the test report.", e );
-		} catch ( final KryoException e ) {
-			logger.error( "The report was created with another, incompatible recheck version.\n"
-					+ "Please use the same recheck version to load a report with which it was generated." );
-			logger.debug( "Stack trace:", e );
+		} catch ( final Exception e ) {
+			ErrorHandler.handle( e, testReport );
 		}
 	}
 

--- a/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
@@ -2,6 +2,7 @@ package de.retest.recheck.cli.subcommands;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -78,6 +79,10 @@ public class Commit implements Runnable {
 		} catch ( final TestReportFormatException e ) {
 			logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
 					Properties.TEST_REPORT_FILE_EXTENSION );
+		} catch ( final NoSuchFileException e ) {
+			logger.error( "The given file report '{}' does not exist. Please check the given file path.",
+					testReport.getAbsolutePath() );
+			logger.debug( "Stack trace:", e );
 		} catch ( final IOException e ) {
 			logger.error( "An error occurred while loading the test report.", e );
 		} catch ( final KryoException e ) {

--- a/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
@@ -72,7 +72,7 @@ public class Commit implements Runnable {
 				checkForWarningAndApplyChanges( reviewResult );
 			}
 		} catch ( final Exception e ) {
-			ErrorHandler.handle( e, testReport );
+			ErrorHandler.handle( e );
 		}
 	}
 

--- a/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
@@ -52,7 +52,7 @@ public class Diff implements Runnable {
 				logger.info( "\n{}", printer.toString( filteredTestReport ) );
 			}
 		} catch ( final Exception e ) {
-			ErrorHandler.handle( e, testReport );
+			ErrorHandler.handle( e );
 		}
 	}
 

--- a/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
@@ -5,6 +5,7 @@ import static de.retest.recheck.printer.DefaultValueFinderProvider.none;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -58,6 +59,10 @@ public class Diff implements Runnable {
 		} catch ( final TestReportFormatException e ) {
 			logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
 					Properties.TEST_REPORT_FILE_EXTENSION );
+		} catch ( final NoSuchFileException e ) {
+			logger.error( "The given file report '{}' does not exist. Please check the given file path.",
+					testReport.getAbsolutePath() );
+			logger.debug( "Stack trace:", e );
 		} catch ( final IOException e ) {
 			logger.error( "An error occurred while loading the test report.", e );
 		} catch ( final KryoException e ) {

--- a/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
@@ -4,18 +4,13 @@ import static de.retest.recheck.ignore.RecheckIgnoreUtil.loadRecheckIgnore;
 import static de.retest.recheck.printer.DefaultValueFinderProvider.none;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.NoSuchFileException;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.esotericsoftware.kryo.KryoException;
-
-import de.retest.recheck.Properties;
 import de.retest.recheck.cli.PreCondition;
-import de.retest.recheck.cli.TestReportFormatException;
+import de.retest.recheck.cli.utils.ErrorHandler;
 import de.retest.recheck.cli.utils.FilterUtil;
 import de.retest.recheck.cli.utils.TestReportUtil;
 import de.retest.recheck.ignore.Filter;
@@ -56,19 +51,8 @@ public class Diff implements Runnable {
 				final TestReportPrinter printer = new TestReportPrinter( none(), loadRecheckIgnore() );
 				logger.info( "\n{}", printer.toString( filteredTestReport ) );
 			}
-		} catch ( final TestReportFormatException e ) {
-			logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
-					Properties.TEST_REPORT_FILE_EXTENSION );
-		} catch ( final NoSuchFileException e ) {
-			logger.error( "The given file report '{}' does not exist. Please check the given file path.",
-					testReport.getAbsolutePath() );
-			logger.debug( "Stack trace:", e );
-		} catch ( final IOException e ) {
-			logger.error( "An error occurred while loading the test report.", e );
-		} catch ( final KryoException e ) {
-			logger.error( "The report was created with another, incompatible recheck version.\n"
-					+ "Please use the same recheck version to load a report with which it was generated." );
-			logger.debug( "Stack trace:", e );
+		} catch ( final Exception e ) {
+			ErrorHandler.handle( e, testReport );
 		}
 	}
 

--- a/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
@@ -3,18 +3,14 @@ package de.retest.recheck.cli.subcommands;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.esotericsoftware.kryo.KryoException;
-
-import de.retest.recheck.Properties;
 import de.retest.recheck.cli.PreCondition;
-import de.retest.recheck.cli.TestReportFormatException;
+import de.retest.recheck.cli.utils.ErrorHandler;
 import de.retest.recheck.cli.utils.TestReportUtil;
 import de.retest.recheck.ignore.RecheckIgnoreUtil;
 import de.retest.recheck.report.ActionReplayResult;
@@ -85,19 +81,8 @@ public class Ignore implements Runnable {
 					return;
 				}
 				saveRecheckIgnore();
-			} catch ( final TestReportFormatException e ) {
-				logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
-						Properties.TEST_REPORT_FILE_EXTENSION );
-			} catch ( final NoSuchFileException e ) {
-				logger.error( "The given file report '{}' does not exist. Please check the given file path.",
-						testReport.getAbsolutePath() );
-				logger.debug( "Stack trace:", e );
-			} catch ( final IOException e ) {
-				logger.error( "An error occurred while loading the test report.", e );
-			} catch ( final KryoException e ) {
-				logger.error( "The report was created with another, incompatible recheck version.\n"
-						+ "Please use the same recheck version to load a report with which it was generated." );
-				logger.debug( "Stack trace:", e );
+			} catch ( final Exception e ) {
+				ErrorHandler.handle( e, testReport );
 			}
 		}
 	}

--- a/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
@@ -82,7 +82,7 @@ public class Ignore implements Runnable {
 				}
 				saveRecheckIgnore();
 			} catch ( final Exception e ) {
-				ErrorHandler.handle( e, testReport );
+				ErrorHandler.handle( e );
 			}
 		}
 	}

--- a/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
@@ -3,6 +3,7 @@ package de.retest.recheck.cli.subcommands;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -87,6 +88,10 @@ public class Ignore implements Runnable {
 			} catch ( final TestReportFormatException e ) {
 				logger.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
 						Properties.TEST_REPORT_FILE_EXTENSION );
+			} catch ( final NoSuchFileException e ) {
+				logger.error( "The given file report '{}' does not exist. Please check the given file path.",
+						testReport.getAbsolutePath() );
+				logger.debug( "Stack trace:", e );
 			} catch ( final IOException e ) {
 				logger.error( "An error occurred while loading the test report.", e );
 			} catch ( final KryoException e ) {

--- a/src/main/java/de/retest/recheck/cli/utils/ErrorHandler.java
+++ b/src/main/java/de/retest/recheck/cli/utils/ErrorHandler.java
@@ -1,6 +1,5 @@
 package de.retest.recheck.cli.utils;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 
@@ -16,7 +15,7 @@ public class ErrorHandler {
 	private ErrorHandler() {
 	}
 
-	public static void handle( final Exception e, final File testReport ) {
+	public static void handle( final Exception e ) {
 		if ( e instanceof TestReportFormatException ) {
 			log.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
 					Properties.TEST_REPORT_FILE_EXTENSION );
@@ -24,7 +23,7 @@ public class ErrorHandler {
 		}
 		if ( e instanceof NoSuchFileException ) {
 			log.error( "The given file report '{}' does not exist. Please check the given file path.",
-					testReport.getAbsolutePath() );
+					((NoSuchFileException) e).getFile() );
 			log.debug( "Stack trace:", e );
 			return;
 		}

--- a/src/main/java/de/retest/recheck/cli/utils/ErrorHandler.java
+++ b/src/main/java/de/retest/recheck/cli/utils/ErrorHandler.java
@@ -1,0 +1,42 @@
+package de.retest.recheck.cli.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+
+import com.esotericsoftware.kryo.KryoException;
+
+import de.retest.recheck.Properties;
+import de.retest.recheck.cli.TestReportFormatException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ErrorHandler {
+
+	private ErrorHandler() {
+	}
+
+	public static void handle( final Exception e, final File testReport ) {
+		if ( e instanceof TestReportFormatException ) {
+			log.error( "The given file is not a test report. Please only pass files using the '{}' extension.",
+					Properties.TEST_REPORT_FILE_EXTENSION );
+			return;
+		}
+		if ( e instanceof NoSuchFileException ) {
+			log.error( "The given file report '{}' does not exist. Please check the given file path.",
+					testReport.getAbsolutePath() );
+			log.debug( "Stack trace:", e );
+			return;
+		}
+		if ( e instanceof IOException ) {
+			log.error( "An error occurred while loading the test report.", e );
+		}
+		if ( e instanceof KryoException ) {
+			log.error( "The report was created with another, incompatible recheck version.\n"
+					+ "Please use the same recheck version to load a report with which it was generated." );
+			log.debug( "Stack trace:", e );
+		}
+		throw new RuntimeException( e );
+	}
+
+}

--- a/src/main/java/de/retest/recheck/cli/utils/ErrorHandler.java
+++ b/src/main/java/de/retest/recheck/cli/utils/ErrorHandler.java
@@ -29,11 +29,13 @@ public class ErrorHandler {
 		}
 		if ( e instanceof IOException ) {
 			log.error( "An error occurred while loading the test report.", e );
+			return;
 		}
 		if ( e instanceof KryoException ) {
 			log.error( "The report was created with another, incompatible recheck version.\n"
 					+ "Please use the same recheck version to load a report with which it was generated." );
 			log.debug( "Stack trace:", e );
+			return;
 		}
 		throw new RuntimeException( e );
 	}

--- a/src/test/java/de/retest/recheck/cli/subcommands/CommitIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/CommitIT.java
@@ -11,6 +11,7 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.contrib.java.lang.system.TextFromStandardInputStream;
 import org.junit.rules.TemporaryFolder;
 
+import de.retest.recheck.Properties;
 import de.retest.recheck.cli.testutils.TestReportCreator;
 import de.retest.recheck.configuration.ProjectConfiguration;
 import picocli.CommandLine;
@@ -111,6 +112,19 @@ public class CommitIT {
 
 		assertThat( systemOutRule.getLog() ).contains(
 				"The given file is not a test report. Please only pass files using the '.report' extension." );
+	}
+
+	@Test
+	public void commit_should_give_proper_error_message_when_given_test_report_does_not_exist() throws Exception {
+		final File doesNotExist = new File( "/does/not/exist" + Properties.TEST_REPORT_FILE_EXTENSION );
+		final String[] args = { "--all", doesNotExist.getAbsolutePath() };
+		final Commit cut = new Commit();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() ).endsWith( "The given file report '" + doesNotExist.getAbsolutePath()
+				+ "' does not exist. Please check the given file path.\n" );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
@@ -11,6 +11,7 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.rules.TemporaryFolder;
 
+import de.retest.recheck.Properties;
 import de.retest.recheck.cli.testutils.ProjectRootFaker;
 import de.retest.recheck.cli.testutils.TestReportCreator;
 import picocli.CommandLine;
@@ -80,5 +81,18 @@ public class DiffIT {
 
 		assertThat( systemOutRule.getLog() ).contains(
 				"The given file is not a test report. Please only pass files using the '.report' extension." );
+	}
+
+	@Test
+	public void diff_should_give_proper_error_message_when_given_test_report_does_not_exist() throws Exception {
+		final File doesNotExist = new File( "/does/not/exist" + Properties.TEST_REPORT_FILE_EXTENSION );
+		final String[] args = { doesNotExist.getAbsolutePath() };
+		final Diff cut = new Diff();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() ).endsWith( "The given file report '" + doesNotExist.getAbsolutePath()
+				+ "' does not exist. Please check the given file path.\n" );
 	}
 }

--- a/src/test/java/de/retest/recheck/cli/subcommands/IgnoreIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/IgnoreIT.java
@@ -11,6 +11,7 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.rules.TemporaryFolder;
 
+import de.retest.recheck.Properties;
 import de.retest.recheck.cli.testutils.TestReportCreator;
 import de.retest.recheck.configuration.ProjectConfiguration;
 import picocli.CommandLine;
@@ -121,5 +122,18 @@ public class IgnoreIT {
 
 		assertThat( systemOutRule.getLog() ).contains(
 				"The given file is not a test report. Please only pass files using the '.report' extension." );
+	}
+
+	@Test
+	public void ignore_should_give_proper_error_message_when_given_test_report_does_not_exist() throws Exception {
+		final File doesNotExist = new File( "/does/not/exist" + Properties.TEST_REPORT_FILE_EXTENSION );
+		final String[] args = { "--all", doesNotExist.getAbsolutePath() };
+		final Ignore cut = new Ignore();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() ).endsWith( "The given file report '" + doesNotExist.getAbsolutePath()
+				+ "' does not exist. Please check the given file path.\n" );
 	}
 }


### PR DESCRIPTION
Printing stack traces in a CLI is ugly. This PR gives better error messages when the passed test report doesn't exist.

However, I marked this as a draft as our current exception handling violates the DRY principle. We essentially got the very same catches in `Commit`, `Diff`, and `Ignore`.

Let's think about this together.