### PR TITLE
Add Mergify config

### DIFF
--- a/mergify.yml
+++ b/mergify.yml
@@ -1,0 +1,14 @@
+pull_request_rules:
+  - name: rebase and merge when the head branch is not a release, one or more reviewers approved and all status checks passed
+    conditions:
+      - "#head~=(!?^release.*)"
+      - "#approved-reviews-by>=1"
+      - status-success=Travis CI - Branch
+      - status-success=Travis CI - Pull Request
+      - status-success=SonarCloud Code Analysis
+      - status-success=verification/cla-signed
+    actions:
+      merge:
+        strict: true
+        strict_method: rebase
+        method: merge


### PR DESCRIPTION
I picked this repo for testing Mergify because I think it is not as critical as e.g. recheck or recheck-web, but still anyone has the chance to work on the project.

So, I tried to incorporate the most important rules:

* Head branch is not a release
* At least one approved review
* All status checks pass

Here is a link to the config if you want to double-check:

https://doc.mergify.io/getting-started.html#configuration

Did I miss something?