### PR TITLE
Do not delete head branches

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,4 +12,3 @@ pull_request_rules:
         strict: true
         strict_method: rebase
         method: merge
-      delete_head_branch: {}


### PR DESCRIPTION
This is done on the repo level and must be evaluated separately as this can cause a delete on close (see e.g. https://github.com/retest/recheck.cli/pull/157).