### PR TITLE
Feature: diff of two golden masters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,11 @@ Table of Contents
 
 * Add `account` sub commands which allow users to login/logout and display the local API key
 
-### Improvements
+* `diff` command: compare any two golden masters. The option `--output` offers the possibility to save 
+the differences as test report in the specified directory, and the option `--exclude` to filter the differences.
+This command may still be used to show results of a test report. But it is advised to use the new command `show` instead.
 
+### Improvements
 
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Command-line interface for recheck.
       --version   Display version info.
 Commands:
   version     Display version info.
-  diff        Display differences of given test report.
+  diff        Compare two Golden Masters.
+  show        Display differences of given test report.
   commit      Accept specified differences of given test report.
   ignore      Ignore specified differences of given test report.
   completion  Generate and display an auto completion script.

--- a/src/main/java/de/retest/recheck/cli/RecheckCli.java
+++ b/src/main/java/de/retest/recheck/cli/RecheckCli.java
@@ -3,6 +3,7 @@ package de.retest.recheck.cli;
 import de.retest.recheck.cli.subcommands.Account;
 import de.retest.recheck.cli.subcommands.Commit;
 import de.retest.recheck.cli.subcommands.Completion;
+import de.retest.recheck.cli.subcommands.Show;
 import de.retest.recheck.cli.subcommands.Diff;
 import de.retest.recheck.cli.subcommands.Ignore;
 import de.retest.recheck.cli.subcommands.Version;
@@ -12,8 +13,9 @@ import picocli.CommandLine.Option;
 
 // TODO Add Migrate command when https://github.com/retest/recheck.cli/issues/85#issuecomment-526102137 is addressed.
 @Command( name = "recheck", description = "Command-line interface for recheck.",
-		versionProvider = VersionProvider.class, subcommands = { Version.class, Diff.class, Commit.class, Ignore.class,
-				Completion.class, CommandLine.HelpCommand.class, Account.class } )
+		versionProvider = VersionProvider.class, subcommands = { Version.class, Show.class, Diff.class, Commit.class,
+				Ignore.class, Completion.class, CommandLine.HelpCommand.class, Account.class } )
+
 public class RecheckCli implements Runnable {
 
 	@Option( names = "--help", usageHelp = true, description = "Display this help message." )

--- a/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
@@ -1,73 +1,164 @@
 package de.retest.recheck.cli.subcommands;
 
-import static de.retest.recheck.printer.DefaultValueFinderProvider.none;
+import static de.retest.recheck.XmlTransformerUtil.getXmlTransformer;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.retest.recheck.cli.PreCondition;
-import de.retest.recheck.cli.TestReportFormatException;
+import de.retest.recheck.RecheckProperties;
+import de.retest.recheck.SuiteAggregator;
 import de.retest.recheck.cli.utils.ErrorHandler;
 import de.retest.recheck.cli.utils.FilterUtil;
-import de.retest.recheck.cli.utils.TestReportUtil;
-import de.retest.recheck.ignore.CompoundFilter;
+import de.retest.recheck.cli.utils.GoldenMasterUtil;
+import de.retest.recheck.execution.RecheckDifferenceFinder;
 import de.retest.recheck.ignore.Filter;
-import de.retest.recheck.printer.TestReportPrinter;
+import de.retest.recheck.persistence.GoldenMasterProvider;
+import de.retest.recheck.persistence.GoldenMasterProviderImpl;
+import de.retest.recheck.persistence.PersistenceFactory;
+import de.retest.recheck.printer.ActionReplayResultPrinter;
+import de.retest.recheck.report.ActionReplayResult;
+import de.retest.recheck.report.SuiteReplayResult;
+import de.retest.recheck.report.TestReplayResult;
 import de.retest.recheck.report.TestReport;
 import de.retest.recheck.report.TestReportFilter;
+import de.retest.recheck.ui.descriptors.SutState;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command( name = "diff", description = "Display differences of given test report." )
+@Command( name = "diff", description = "Compare two Golden Masters." )
 public class Diff implements Runnable {
 
 	private static final Logger logger = LoggerFactory.getLogger( Diff.class );
 
-	@Option( names = "--help", usageHelp = true, hidden = true )
-	private boolean displayHelp;
+	private static final PersistenceFactory persistenceFactory = new PersistenceFactory( getXmlTransformer() );
+	private static final GoldenMasterProvider goldenMasterProvider =
+			new GoldenMasterProviderImpl( persistenceFactory.getPersistence() );
+
+	private static final String TEST_NAME = "Test - Golden Master Comparison";
+	private static final String SUITE_NAME = "Suite - Golden Master Comparison";
+
+	// TODO Temporarily it will be allowed to use the diff command for display of test reports
+	// TODO Will be removed in following version (see RET-1956); instead, use the command "show"
+	@Parameters( arity = "1..2", description = GoldenMasterUtil.GOLDEN_MASTER_PARAMETER_DESCRIPTION )
+	private Path[] goldenMasterPath;
 
 	@Option( names = "--exclude", description = FilterUtil.EXCLUDE_OPTION_DESCRIPTION )
 	private List<String> exclude;
 
-	@Parameters( arity = "1", description = TestReportUtil.TEST_REPORT_PARAMETER_DESCRIPTION )
-	private File testReport;
+	@Option( names = "--help", usageHelp = true, hidden = true )
+	private boolean displayHelp;
+
+	@Option( names = "--output", arity = "1",
+			description = "Save differences of Golden Masters to specified directory as test report." )
+	private Path directory;
 
 	@Override
 	public void run() {
-		if ( !PreCondition.isSatisfied() ) {
-			return;
-		}
-		try {
-			final List<String> invalidFilters = FilterUtil.getInvalidFilters( exclude );
-			if ( !invalidFilters.isEmpty() ) {
-				FilterUtil.logWarningForInvalidFilters( invalidFilters );
-			} else {
-				printDiff();
+		// TODO: until the following version (see RET-1956), a user may still use the diff command to print test report differences.
+		// TODO: remove in next version (see RET-1956)
+		if ( goldenMasterPath.length == 1 ) {
+			logger.warn(
+					"The diff command for viewing a test report is deprecated and will be removed in the following version."
+							+ " Please use the new command 'show' to display a test report." );
+
+			final List<String> argsAsList = new ArrayList<>();
+			argsAsList.add( goldenMasterPath[0].toString() );
+			if ( exclude != null ) {
+				for ( final String filter : exclude ) {
+					argsAsList.add( "--exclude" );
+					argsAsList.add( filter );
+				}
 			}
-		} catch ( final Exception e ) {
-			ErrorHandler.handle( e );
+
+			final String[] args = argsAsList.toArray( new String[0] );
+			new CommandLine( new Show() ).execute( args );
+
+		} else {
+
+			final Path expectedSutStatePath = goldenMasterPath[0];
+			final Path actualSutStatePath = goldenMasterPath[1];
+
+			try {
+				if ( !FilterUtil.hasValidExcludeOption( exclude ) ) {
+					return;
+				}
+				final ActionReplayResult actionReplayResult =
+						createActionReplayResultFrom( expectedSutStatePath, actualSutStatePath );
+				printGoldenMasterDifferences( filterActionReplayResult( actionReplayResult ) );
+				persistIfOutputOptionPresent( actionReplayResult );
+			} catch ( final Exception e ) {
+				ErrorHandler.handle( e );
+			}
 		}
 	}
 
-	private void printDiff() throws TestReportFormatException, IOException {
-		final TestReport report = TestReportUtil.load( testReport );
-		final Filter excludeFilter = FilterUtil.getExcludeFilterFiles( exclude );
-		final Filter recheckIgnore = FilterUtil.loadRecheckIgnore();
-		final TestReportFilter filter = new TestReportFilter( new CompoundFilter( excludeFilter, recheckIgnore ) );
-		final TestReport filteredTestReport = filter.filter( report );
-		final TestReportPrinter printer = new TestReportPrinter( none() );
+	private ActionReplayResult createActionReplayResultFrom( final Path expectedSutStatePath,
+			final Path actualSutStatePath ) {
+		final SutState expectedSutState = loadGoldenMaster( expectedSutStatePath );
+		final SutState actualSutState = loadGoldenMaster( actualSutStatePath );
 
-		logger.info( "\n{}", printer.toString( filteredTestReport ) );
+		return findDifferences( expectedSutStatePath.toString(), expectedSutState, actualSutState );
+	}
 
-		if ( filteredTestReport.getDifferencesCount() > 0 ) {
-			logger.info( "\nOverall, recheck found {} difference(s) when checking {} element(s).",
-					filteredTestReport.getDifferencesCount(), filteredTestReport.getCheckedUiElementsCount() );
+	private SutState loadGoldenMaster( final Path actualSutStatePath ) {
+		return goldenMasterProvider
+				.loadGoldenMaster( actualSutStatePath.resolve( RecheckProperties.DEFAULT_XML_FILE_NAME ).toFile() );
+	}
+
+	private ActionReplayResult findDifferences( final String expectedSutStatePath, final SutState expectedSutState,
+			final SutState actualSutState ) {
+		final RecheckDifferenceFinder differenceFinder = new RecheckDifferenceFinder(
+				( attributes, s, serializable ) -> false, "Comparison of Golden Masters", expectedSutStatePath );
+		return differenceFinder.findDifferences( expectedSutState, actualSutState );
+	}
+
+	private void printGoldenMasterDifferences( final ActionReplayResult actionReplayResult ) {
+		final ActionReplayResultPrinter printer =
+				new ActionReplayResultPrinter( ( attributes, s, serializable ) -> false );
+
+		logger.info( "\n{}", printer.toString( actionReplayResult ) );
+
+		final int differenceCount = actionReplayResult.getDifferences().size();
+		if ( differenceCount > 0 ) {
+			logger.info( "\nOverall, recheck found {} difference(s) when checking {} element(s).", differenceCount,
+					actionReplayResult.getCheckedUiElementsCount() );
 		}
+	}
+
+	private ActionReplayResult filterActionReplayResult( final ActionReplayResult actionReplayResult ) {
+		final Filter excludeFilter = FilterUtil.getExcludeFilterFiles( exclude );
+		final TestReportFilter reportFilter = new TestReportFilter( (excludeFilter) );
+		return reportFilter.filter( actionReplayResult );
+	}
+
+	private void persistIfOutputOptionPresent( final ActionReplayResult actionReplayResult ) throws IOException {
+		if ( directory != null ) {
+			persist( actionReplayResult, directory );
+			return;
+		}
+		logger.info( "\nThe displayed differences may be saved as test report by using the --output option." );
+	}
+
+	private void persist( final ActionReplayResult result, final Path outputDirectory ) throws IOException {
+		final TestReplayResult testPlayResult = new TestReplayResult( TEST_NAME, 1 );
+		final SuiteReplayResult suiteReplayResult = SuiteAggregator.getInstance().getSuite( SUITE_NAME );
+		testPlayResult.addAction( result );
+		suiteReplayResult.addTest( testPlayResult );
+		final TestReport testReport = new TestReport( suiteReplayResult );
+
+		final File report = outputDirectory.resolve( RecheckProperties.AGGREGATED_TEST_REPORT_FILE_NAME ).toFile();
+
+		persistenceFactory.getPersistence().save( report.toURI(), testReport );
+
+		logger.info( "\nThe test report has been saved to '{}'.", report.getAbsolutePath() );
 	}
 
 }

--- a/src/main/java/de/retest/recheck/cli/subcommands/Migrate.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Migrate.java
@@ -67,7 +67,7 @@ public class Migrate implements Runnable {
 		final String path = !goldenMasterPath.equals( "" ) ? goldenMasterPath : RECHECK_FOLDER;
 		final File goldenMaster = ProjectRootFinderUtil.getProjectRoot()
 				.map( gmPath -> Paths.get( gmPath.toAbsolutePath().toString(), path ) ).map( Path::toFile )
-				.orElseThrow( () -> new IOException() );
+				.orElseThrow( IOException::new );
 		try ( final Stream<Path> goldenMasterPaths = Files.walk( goldenMaster.toPath() ) ) {
 			return goldenMasterPaths.filter( gmPath -> gmPath.endsWith( RecheckProperties.DEFAULT_XML_FILE_NAME ) )
 					.map( gmPath -> gmPath.getParent().toString() ).collect( Collectors.toList() );

--- a/src/main/java/de/retest/recheck/cli/subcommands/Show.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Show.java
@@ -1,0 +1,70 @@
+package de.retest.recheck.cli.subcommands;
+
+import static de.retest.recheck.printer.DefaultValueFinderProvider.none;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.retest.recheck.cli.PreCondition;
+import de.retest.recheck.cli.TestReportFormatException;
+import de.retest.recheck.cli.utils.ErrorHandler;
+import de.retest.recheck.cli.utils.FilterUtil;
+import de.retest.recheck.cli.utils.TestReportUtil;
+import de.retest.recheck.ignore.CompoundFilter;
+import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.printer.TestReportPrinter;
+import de.retest.recheck.report.TestReport;
+import de.retest.recheck.report.TestReportFilter;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+@Command( name = "show", description = "Display differences of given test report." )
+public class Show implements Runnable {
+
+	private static final Logger logger = LoggerFactory.getLogger( Show.class );
+
+	@Option( names = "--help", usageHelp = true, hidden = true )
+	private boolean displayHelp;
+
+	@Option( names = "--exclude", description = FilterUtil.EXCLUDE_OPTION_DESCRIPTION )
+	private List<String> exclude;
+
+	@Parameters( arity = "1", description = TestReportUtil.TEST_REPORT_PARAMETER_DESCRIPTION )
+	private File testReport;
+
+	@Override
+	public void run() {
+		if ( !PreCondition.isSatisfied() ) {
+			return;
+		}
+		try {
+			if ( FilterUtil.hasValidExcludeOption( exclude ) ) {
+				printDiff();
+			}
+		} catch ( final Exception e ) {
+			ErrorHandler.handle( e );
+		}
+	}
+
+	private void printDiff() throws TestReportFormatException, IOException {
+		final TestReport report = TestReportUtil.load( testReport );
+		final Filter excludeFilter = FilterUtil.getExcludeFilterFiles( exclude );
+		final Filter recheckIgnore = FilterUtil.loadRecheckIgnore();
+		final TestReportFilter filter = new TestReportFilter( new CompoundFilter( excludeFilter, recheckIgnore ) );
+		final TestReport filteredTestReport = filter.filter( report );
+		final TestReportPrinter printer = new TestReportPrinter( none() );
+
+		logger.info( "\n{}", printer.toString( filteredTestReport ) );
+
+		if ( filteredTestReport.getDifferencesCount() > 0 ) {
+			logger.info( "\nOverall, recheck found {} difference(s) when checking {} element(s).",
+					filteredTestReport.getDifferencesCount(), filteredTestReport.getCheckedUiElementsCount() );
+		}
+	}
+
+}

--- a/src/main/java/de/retest/recheck/cli/utils/ErrorHandler.java
+++ b/src/main/java/de/retest/recheck/cli/utils/ErrorHandler.java
@@ -1,6 +1,7 @@
 package de.retest.recheck.cli.utils;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.NoSuchFileException;
 
 import com.esotericsoftware.kryo.KryoException;
@@ -26,14 +27,18 @@ public class ErrorHandler {
 			log.debug( "Stack trace:", e );
 			return;
 		}
-		if ( e instanceof IOException ) {
-			log.error( "An error occurred while loading the test report.", e );
-			return;
-		}
 		if ( e instanceof KryoException ) {
 			log.error( "The report was created with another, incompatible recheck version.\n"
 					+ "Please use the same recheck version to load a report with which it was generated." );
 			log.debug( "Stack trace:", e );
+			return;
+		}
+		if ( e instanceof UncheckedIOException ) {
+			log.error( "\n{}", e.getMessage() );
+			return;
+		}
+		if ( e instanceof IOException ) {
+			log.error( "An error occurred while loading or saving the test report.", e );
 			return;
 		}
 		throw new RuntimeException( e );

--- a/src/main/java/de/retest/recheck/cli/utils/FilterUtil.java
+++ b/src/main/java/de/retest/recheck/cli/utils/FilterUtil.java
@@ -52,7 +52,7 @@ public class FilterUtil {
 	}
 
 	public static void logWarningForInvalidFilters( final List<String> invalidFilters ) {
-		final String filter = invalidFilters.stream().collect( Collectors.joining( ", " ) );
+		final String filter = String.join( ", ", invalidFilters );
 		log.warn( "The invalid filter files are: {}", filter );
 	}
 
@@ -65,4 +65,14 @@ public class FilterUtil {
 		}
 		return Filter.FILTER_NOTHING;
 	}
+
+	public static boolean hasValidExcludeOption( final List<String> exclude ) {
+		final List<String> invalidFilters = getInvalidFilters( exclude );
+		if ( !invalidFilters.isEmpty() ) {
+			logWarningForInvalidFilters( invalidFilters );
+			return false;
+		}
+		return true;
+	}
+
 }

--- a/src/main/java/de/retest/recheck/cli/utils/GoldenMasterUtil.java
+++ b/src/main/java/de/retest/recheck/cli/utils/GoldenMasterUtil.java
@@ -1,0 +1,11 @@
+package de.retest.recheck.cli.utils;
+
+public class GoldenMasterUtil {
+
+	public static final String GOLDEN_MASTER_PARAMETER_DESCRIPTION =
+			"Path to a golden master folder. This command may also "
+					+ "be used with a single parameter to print out a test report (deprecated)."; //
+
+	private GoldenMasterUtil() {}
+
+}

--- a/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
@@ -3,6 +3,7 @@ package de.retest.recheck.cli.subcommands;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,12 +12,13 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.rules.TemporaryFolder;
 
 import de.retest.recheck.RecheckProperties;
+import de.retest.recheck.cli.testutils.GoldenMasterCreator;
 import de.retest.recheck.cli.testutils.ProjectRootFaker;
 import de.retest.recheck.cli.testutils.TestReportCreator;
+import de.retest.recheck.util.FileUtil;
 import picocli.CommandLine;
 
 public class DiffIT {
-
 	@Rule
 	public final TemporaryFolder temp = new TemporaryFolder();
 
@@ -28,22 +30,210 @@ public class DiffIT {
 
 	@Test
 	public void diff_without_argument_should_return_the_usage_message() {
-		final String expected =
-				"Usage: diff [--exclude=<exclude>]... <testReport>\n" + "Display differences of given test report.\n"
-						+ "      <testReport>          Path to a test report file (.report extension). If\n"
-						+ "                              the test report is not in the project directory,\n"
-						+ "                              please specify the absolute path, otherwise a\n"
-						+ "                              relative path is sufficient.\n"
-						+ "      --exclude=<exclude>   Filter to exclude changes from the report. For a\n"
-						+ "                              custom filter, please specify the absolute path.\n"
-						+ "                              For predefined filters, a relative path is\n"
-						+ "                              sufficient. Specify this option multiple times to\n"
-						+ "                              use more than one filter.\n";
+		final String expected = "Usage: diff [--output=<directory>] [--exclude=<exclude>]...\n"
+				+ "            <goldenMasterPath>..." + "Compare two Golden Masters.\n"
+				+ "      <goldenMasterPath>...  Path to a golden master folder. This command may\n"
+				+ "                               also be used with a single parameter to print\n"
+				+ "                               out a test report (deprecated).\n"
+				+ "      --exclude=<exclude>    Filter to exclude changes from the report. For a\n"
+				+ "                               custom filter, please specify the absolute path.\n"
+				+ "                               For predefined filters, a relative path is\n"
+				+ "                               sufficient. Specify this option multiple times\n"
+				+ "                               to use more than one filter.\n"
+				+ "      --output=<directory>   Save differences of Golden Masters to specified\n"
+				+ "                               directory as test report.\n";
+
 		assertThat( new CommandLine( new Diff() ).getUsageMessage() ).isEqualToIgnoringNewLines( expected );
 	}
 
 	@Test
-	public void diff_should_print_differences() throws Exception {
+	public void diff_should_give_proper_error_message_when_given_golden_master_path_does_not_exist() throws Exception {
+		temp.newFolder( "someotherpath" );
+		temp.newFolder( "someotherpath", "goldenmaster" );
+
+		final File outputDir = temp.newFolder( "somedirectory" );
+
+		final File doesNotExist = temp.newFile( "doesnotexist" );
+		final String[] args = { "--output", outputDir.getAbsolutePath(), doesNotExist.getAbsolutePath(), "does/exist" };
+		final Diff cut = new Diff();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() ).contains( "Could not load Golden Master from file '"
+				+ FileUtil.canonicalFileQuietly( new File( doesNotExist, RecheckProperties.DEFAULT_XML_FILE_NAME ) )
+				+ "'." );
+	}
+
+	@Test
+	public void diff_should_provide_proper_error_message_when_provided_file_not_a_golden_master() throws IOException {
+		temp.newFolder( "path" );
+		temp.newFolder( "path", "notagoldenmaster" );
+		temp.newFolder( "someotherpath" );
+		temp.newFolder( "someotherpath", "goldenmaster" );
+
+		final File notAGoldenMaster = temp.newFolder( "path", "notagoldenmaster", "a" );
+		final File aGoldenMaster = temp.newFolder( "someotherpath", "goldenmaster", "b" );
+
+		final File outputDir = temp.newFolder( "somedirectory" );
+
+		GoldenMasterCreator.createErroneousGoldenMasterFile( notAGoldenMaster );
+		GoldenMasterCreator.createGoldenMasterFile( aGoldenMaster, true );
+
+		final File expectedPathErroneousFile =
+				new File( FileUtil.canonicalFileQuietly( notAGoldenMaster ), RecheckProperties.DEFAULT_XML_FILE_NAME );
+
+		final String[] args = { "--output", outputDir.getAbsolutePath(), notAGoldenMaster.getAbsolutePath(),
+				aGoldenMaster.getAbsolutePath() };
+
+		final Diff cut = new Diff();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() ).containsSubsequence(
+				"Could not load Golden Master from file '" + expectedPathErroneousFile.getAbsolutePath() + "'." );
+
+	}
+
+	@Test
+	public void diff_should_print_differences_of_golden_masters() throws IOException {
+		temp.newFolder( "path" );
+		temp.newFolder( "path", "goldenmaster" );
+		temp.newFolder( "someotherpath" );
+		temp.newFolder( "someotherpath", "goldenmaster" );
+
+		final File outputDir = temp.newFolder( "somedirectory" );
+
+		final File gm1 = temp.newFolder( "path", "goldenmaster", "a" );
+		final File gm2 = temp.newFolder( "someotherpath", "goldenmaster", "b" );
+
+		GoldenMasterCreator.createGoldenMasterFile( gm1, true );
+		GoldenMasterCreator.createGoldenMasterFile( gm2, false );
+
+		final String[] args = { "--output", outputDir.getAbsolutePath(), gm1.getAbsolutePath(), gm2.getAbsolutePath() };
+		final Diff cut = new Diff();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		final String expected = "Comparison of Golden Masters resulted in:\n" //
+				+ "\tMetadata Differences:\n" //
+				+ "\t	some.driver: expected=\"driverA\", actual=\"driverB\"\n" //
+				+ "\tbaz [changed text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t	was deleted\n" //
+				+ "\tbaz [original text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t	was inserted\n";
+
+		assertThat( systemOutRule.getLog() ).containsSubsequence( expected );
+	}
+
+	@Test
+	public void diff_should_not_persist_testreport_if_no_output_option() throws IOException {
+		temp.newFolder( "path" );
+		temp.newFolder( "path", "goldenmaster" );
+		temp.newFolder( "someotherpath" );
+		temp.newFolder( "someotherpath", "goldenmaster" );
+
+		final File gm1 = temp.newFolder( "path", "goldenmaster", "a" );
+		final File gm2 = temp.newFolder( "someotherpath", "goldenmaster", "b" );
+
+		GoldenMasterCreator.createGoldenMasterFile( gm1, true );
+		GoldenMasterCreator.createGoldenMasterFile( gm2, false );
+
+		final String[] args = { gm1.getAbsolutePath(), gm2.getAbsolutePath() };
+		final Diff cut = new Diff();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() )
+				.containsSubsequence( "Overall, recheck found 2 difference(s) when checking 2 element(s).\n" );
+	}
+
+	@Test
+	public void diff_should_persist_testreport_if_output_option() throws IOException {
+		temp.newFolder( "path" );
+		temp.newFolder( "path", "goldenmaster" );
+		temp.newFolder( "someotherpath" );
+		temp.newFolder( "someotherpath", "goldenmaster" );
+
+		final File outputDir = temp.newFolder( "somedirectory" );
+
+		final File gm1 = temp.newFolder( "path", "goldenmaster", "a" );
+		final File gm2 = temp.newFolder( "someotherpath", "goldenmaster", "b" );
+
+		GoldenMasterCreator.createGoldenMasterFile( gm1, true );
+		GoldenMasterCreator.createGoldenMasterFile( gm2, false );
+
+		final File outputFile = new File( outputDir, RecheckProperties.AGGREGATED_TEST_REPORT_FILE_NAME );
+
+		final String[] args = { "--output", outputDir.getAbsolutePath(), gm1.getAbsolutePath(), gm2.getAbsolutePath() };
+		final Diff cut = new Diff();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( outputFile ).exists();
+	}
+
+	@Test
+	public void diff_should_apply_ignore_filter_with_exclude_option() throws IOException {
+		temp.newFolder( "path" );
+		temp.newFolder( "path", "goldenmaster" );
+		temp.newFolder( "someotherpath" );
+		temp.newFolder( "someotherpath", "goldenmaster" );
+
+		final File outputDir = temp.newFolder( "somedirectory" );
+
+		final File gm1 = temp.newFolder( "path", "goldenmaster", "a" );
+		final File gm2 = temp.newFolder( "someotherpath", "goldenmaster", "b" );
+
+		GoldenMasterCreator.createGoldenMasterFile( gm1, true );
+		GoldenMasterCreator.createGoldenMasterFile( gm2, false );
+
+		final File outputFile = new File( outputDir, RecheckProperties.AGGREGATED_TEST_REPORT_FILE_NAME );
+
+		final String[] args = { gm1.getAbsolutePath(), gm2.getAbsolutePath(), "--output", outputDir.toString() };
+		final Diff cut = new Diff();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( outputFile ).exists();
+	}
+
+	@Test
+	public void diff_should_print_warning_when_exclude_option_with_invalid_filters() throws IOException {
+		temp.newFolder( "path" );
+		temp.newFolder( "path", "goldenmaster" );
+		temp.newFolder( "someotherpath" );
+		temp.newFolder( "someotherpath", "goldenmaster" );
+
+		final File outputDir = temp.newFolder( "somedirectory" );
+
+		final File gm1 = temp.newFolder( "path", "goldenmaster", "a" );
+		final File gm2 = temp.newFolder( "someotherpath", "goldenmaster", "b" );
+
+		GoldenMasterCreator.createGoldenMasterFile( gm1, true );
+		GoldenMasterCreator.createGoldenMasterFile( gm2, false );
+
+		final File outputFile = new File( outputDir, RecheckProperties.AGGREGATED_TEST_REPORT_FILE_NAME );
+
+		final String[] args = { "--exclude", "sty-attributes.filter", "--exclude", "invisib.filter", "--output",
+				outputDir.getAbsolutePath(), gm1.getAbsolutePath(), gm2.getAbsolutePath() };
+		final Diff cut = new Diff();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() )
+				.endsWith( "The invalid filter files are: sty-attributes.filter, invisib.filter\n" );
+	}
+
+	// remove this test in next version when old diff functionality is provided only under new command (see RET-1956)
+	@Test
+	public void diff_should_print_diff_of_test_report_if_used_with_single_parameter() throws IOException {
 		ProjectRootFaker.fakeProjectRoot( temp.getRoot().toPath() );
 		final String[] args =
 				{ TestReportCreator.createTestReportFileWithDiffs( temp, "diff_should_print_differences" ) };
@@ -51,6 +241,7 @@ public class DiffIT {
 		new CommandLine( cut ).parseArgs( args );
 
 		cut.run();
+
 		final String expected = "Suite 'diff_should_print_differences' has 3 difference(s) in 1 test(s):\n" //
 				+ "\tTest 'test' has 3 difference(s) in 3 state(s):\n" //
 				+ "\tcheck resulted in:\n" //
@@ -66,29 +257,30 @@ public class DiffIT {
 		assertThat( systemOutRule.getLog() ).contains( expected );
 	}
 
+	// remove this test in next version when old diff functionality is provided only under new command (see RET-1956)
 	@Test
-	public void diff_should_give_proper_error_message_when_given_test_report_is_not_a_test_report() throws Exception {
-		final File notATestReport = temp.newFile();
-		final String[] args = { notATestReport.getAbsolutePath() };
+	public void diff_should_print_diff_of_test_report_if_used_with_single_parameter_and_exclude_option()
+			throws IOException {
+		ProjectRootFaker.fakeProjectRoot( temp.getRoot().toPath() );
+		final String[] args = { "--exclude", "invisible-attributes.filter", "--exclude", "positioning.filter",
+				TestReportCreator.createTestReportFileWithDiffs( temp ) };
 		final Diff cut = new Diff();
 		new CommandLine( cut ).parseArgs( args );
 
 		cut.run();
 
-		assertThat( systemOutRule.getLog() ).contains(
-				"The given file is not a test report. Please only pass files using the '.report' extension." );
+		final String expected = "\tTest 'test' has 3 difference(s) in 3 state(s):\n" //
+				+ "\tcheck resulted in:\n" //
+				+ "\t	baz [original text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t		text: expected=\"original text\", actual=\"changed text\"\n" //
+				+ "\tcheck resulted in:\n" //
+				+ "\t	baz [original text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t		was deleted\n" //
+				+ "\tcheck resulted in:\n" //
+				+ "\t	baz [changed text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t		was inserted";
+
+		assertThat( systemOutRule.getLog() ).contains( expected );
 	}
 
-	@Test
-	public void diff_should_give_proper_error_message_when_given_test_report_does_not_exist() throws Exception {
-		final File doesNotExist = new File( "/does/not/exist" + RecheckProperties.TEST_REPORT_FILE_EXTENSION );
-		final String[] args = { doesNotExist.getAbsolutePath() };
-		final Diff cut = new Diff();
-		new CommandLine( cut ).parseArgs( args );
-
-		cut.run();
-
-		assertThat( systemOutRule.getLog() ).contains( "The given file report '" + doesNotExist.getAbsolutePath()
-				+ "' does not exist. Please check the given file path." );
-	}
 }

--- a/src/test/java/de/retest/recheck/cli/subcommands/ShowIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/ShowIT.java
@@ -1,0 +1,94 @@
+package de.retest.recheck.cli.subcommands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.junit.rules.TemporaryFolder;
+
+import de.retest.recheck.RecheckProperties;
+import de.retest.recheck.cli.testutils.ProjectRootFaker;
+import de.retest.recheck.cli.testutils.TestReportCreator;
+import picocli.CommandLine;
+
+public class ShowIT {
+
+	@Rule
+	public final TemporaryFolder temp = new TemporaryFolder();
+
+	@Rule
+	public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+
+	@Rule
+	public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+	@Test
+	public void show_without_argument_should_return_the_usage_message() {
+		final String expected =
+				"Usage: show [--exclude=<exclude>]... <testReport>\n" + "Display differences of given test report.\n"
+						+ "      <testReport>          Path to a test report file (.report extension). If\n"
+						+ "                              the test report is not in the project directory,\n"
+						+ "                              please specify the absolute path, otherwise a\n"
+						+ "                              relative path is sufficient.\n"
+						+ "      --exclude=<exclude>   Filter to exclude changes from the report. For a\n"
+						+ "                              custom filter, please specify the absolute path.\n"
+						+ "                              For predefined filters, a relative path is\n"
+						+ "                              sufficient. Specify this option multiple times to\n"
+						+ "                              use more than one filter.\n";
+		assertThat( new CommandLine( new Show() ).getUsageMessage() ).isEqualToIgnoringNewLines( expected );
+	}
+
+	@Test
+	public void show_should_print_differences() throws Exception {
+		ProjectRootFaker.fakeProjectRoot( temp.getRoot().toPath() );
+		final String[] args =
+				{ TestReportCreator.createTestReportFileWithDiffs( temp, "diff_should_print_differences" ) };
+		final Show cut = new Show();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+		final String expected = "Suite 'diff_should_print_differences' has 3 difference(s) in 1 test(s):\n" //
+				+ "\tTest 'test' has 3 difference(s) in 3 state(s):\n" //
+				+ "\tcheck resulted in:\n" //
+				+ "\t	baz [original text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t		text: expected=\"original text\", actual=\"changed text\"\n" //
+				+ "\tcheck resulted in:\n" //
+				+ "\t	baz [original text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t		was deleted\n" //
+				+ "\tcheck resulted in:\n" //
+				+ "\t	baz [changed text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t		was inserted";
+
+		assertThat( systemOutRule.getLog() ).contains( expected );
+	}
+
+	@Test
+	public void show_should_give_proper_error_message_when_given_test_report_is_not_a_test_report() throws Exception {
+		final File notATestReport = temp.newFile();
+		final String[] args = { notATestReport.getAbsolutePath() };
+		final Show cut = new Show();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() ).contains(
+				"The given file is not a test report. Please only pass files using the '.report' extension." );
+	}
+
+	@Test
+	public void show_should_give_proper_error_message_when_given_test_report_does_not_exist() throws Exception {
+		final File doesNotExist = new File( "/does/not/exist" + RecheckProperties.TEST_REPORT_FILE_EXTENSION );
+		final String[] args = { doesNotExist.getAbsolutePath() };
+		final Show cut = new Show();
+		new CommandLine( cut ).parseArgs( args );
+
+		cut.run();
+
+		assertThat( systemOutRule.getLog() ).contains( "The given file report '" + doesNotExist.getAbsolutePath()
+				+ "' does not exist. Please check the given file path." );
+	}
+}

--- a/src/test/java/de/retest/recheck/cli/testutils/GoldenMasterCreator.java
+++ b/src/test/java/de/retest/recheck/cli/testutils/GoldenMasterCreator.java
@@ -1,0 +1,51 @@
+package de.retest.recheck.cli.testutils;
+
+import static de.retest.recheck.cli.testutils.RootElementsCreator.createRootElements;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+
+import de.retest.recheck.RecheckProperties;
+import de.retest.recheck.persistence.GoldenMasterProviderImpl;
+import de.retest.recheck.persistence.Persistence;
+import de.retest.recheck.persistence.PersistenceFactory;
+import de.retest.recheck.persistence.xml.util.StdXmlClassesProvider;
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.descriptors.SutState;
+
+public class GoldenMasterCreator {
+
+	public static void createGoldenMasterFile( final File file, final boolean diff ) {
+		final List<RootElement> set = createRootElements( diff );
+		final SutState goldenMaster = new SutState( set, () -> createMetaData( diff ) );
+		final GoldenMasterProviderImpl goldenMasterProvider =
+				new GoldenMasterProviderImpl( createSutStatePersistence() );
+		goldenMasterProvider
+				.saveGoldenMaster( new File( file.getPath(), RecheckProperties.DEFAULT_XML_FILE_NAME ), goldenMaster );
+	}
+
+	public static void createErroneousGoldenMasterFile( final File file ) throws IOException {
+		FileUtils.writeStringToFile( new File( file.getPath(), RecheckProperties.DEFAULT_XML_FILE_NAME ),
+				"erroneousGoldenMaster", Charset.defaultCharset() );
+	}
+
+	private static Map<String, String> createMetaData( final boolean diff ) {
+		final Map<String, String> metaData = new HashMap<>();
+		metaData.put( "some.driver", diff ? "driverA" : "driverB" );
+		return metaData;
+	}
+
+	private static Persistence<SutState> createSutStatePersistence() {
+		return new PersistenceFactory( new HashSet<>( Arrays.asList( StdXmlClassesProvider.getXmlDataClasses() ) ) )
+				.getPersistence();
+	}
+
+}

--- a/src/test/java/de/retest/recheck/cli/testutils/RootElementsCreator.java
+++ b/src/test/java/de/retest/recheck/cli/testutils/RootElementsCreator.java
@@ -1,0 +1,30 @@
+package de.retest.recheck.cli.testutils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import de.retest.recheck.ui.Path;
+import de.retest.recheck.ui.descriptors.Attribute;
+import de.retest.recheck.ui.descriptors.Attributes;
+import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.descriptors.PathAttribute;
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.descriptors.StringAttribute;
+import de.retest.recheck.ui.descriptors.TextAttribute;
+
+public class RootElementsCreator {
+
+	static List<RootElement> createRootElements( final boolean diff ) {
+		final RootElement root = new RootElement( "someRetestId", new IdentifyingAttributes( getAttributes( diff ) ),
+				new Attributes(), null, "someScreen", 0, "someTitle" );
+		return Collections.singletonList( root );
+	}
+
+	static List<Attribute> getAttributes( final boolean diff ) {
+		final Attribute path = new PathAttribute( Path.fromString( "foo[1]/bar[1]/baz[1]" ) );
+		final Attribute string = new StringAttribute( "type", "baz" );
+		final Attribute text = new TextAttribute( "text", diff ? "changed text" : "original text" );
+		return Arrays.asList( path, string, text );
+	}
+}

--- a/src/test/java/de/retest/recheck/cli/testutils/TestReportCreator.java
+++ b/src/test/java/de/retest/recheck/cli/testutils/TestReportCreator.java
@@ -1,8 +1,9 @@
 package de.retest.recheck.cli.testutils;
 
+import static de.retest.recheck.cli.testutils.RootElementsCreator.createRootElements;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -19,15 +20,8 @@ import de.retest.recheck.report.action.ActionReplayData;
 import de.retest.recheck.report.action.DifferenceRetriever;
 import de.retest.recheck.report.action.WindowRetriever;
 import de.retest.recheck.ui.DefaultValueFinder;
-import de.retest.recheck.ui.Path;
-import de.retest.recheck.ui.descriptors.Attribute;
-import de.retest.recheck.ui.descriptors.Attributes;
-import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
-import de.retest.recheck.ui.descriptors.PathAttribute;
 import de.retest.recheck.ui.descriptors.RootElement;
-import de.retest.recheck.ui.descriptors.StringAttribute;
 import de.retest.recheck.ui.descriptors.SutState;
-import de.retest.recheck.ui.descriptors.TextAttribute;
 import de.retest.recheck.ui.diff.ElementIdentificationWarning;
 import de.retest.recheck.ui.diff.RootElementDifference;
 import de.retest.recheck.ui.diff.RootElementDifferenceFinder;
@@ -114,12 +108,6 @@ public class TestReportCreator {
 		return suite;
 	}
 
-	private static List<RootElement> createRootElements( final boolean diff ) {
-		final RootElement root = new RootElement( "someRetestId", new IdentifyingAttributes( getAttributes( diff ) ),
-				new Attributes(), null, "someScreen", 0, "someTitle" );
-		return Collections.singletonList( root );
-	}
-
 	private static List<RootElementDifference> createRootElementDifferences( final List<RootElement> rootElements ) {
 		final RootElementDifference difference = getRootElementDifferenceFinder().findDifference( rootElements.get( 0 ),
 				createRootElements( true ).get( 0 ) );
@@ -139,16 +127,9 @@ public class TestReportCreator {
 		return Collections.singletonList( insertedDifference );
 	}
 
-	private static RootElementDifferenceFinder getRootElementDifferenceFinder() {
+	static RootElementDifferenceFinder getRootElementDifferenceFinder() {
 		final DefaultValueFinder defaultFinder = ( identifyingAttributes, attributeKey, attributeValue ) -> false;
 		return new RootElementDifferenceFinder( defaultFinder );
-	}
-
-	private static List<Attribute> getAttributes( final boolean diff ) {
-		final Attribute a0 = new PathAttribute( Path.fromString( "foo[1]/bar[1]/baz[1]" ) );
-		final Attribute a1 = new StringAttribute( "type", "baz" );
-		final Attribute a2 = new TextAttribute( "text", diff ? "changed text" : "original text" );
-		return Arrays.asList( a0, a1, a2 );
 	}
 
 }


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [ ] <del>all status checks (Travis CI, SonarCloud, etc.) pass.</del> _to discuss: code smells_
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] <del>you updated necessary documentation within [retest/docs](https://github.com/retest/docs).</del> _to discuss_

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> The new `diff` command allows a user to compare any two golden masters. The results are displayed as (filtered) `ActionReplayResult` and the user has the option via `--output` to save the result as a `TestReport` to a specified directory, and to apply filters by using `--exclude` . 

> The previous `diff` command (to display already created results of a test report) is renamed to `show`. For a transitional period, the `diff` command may still be used to display a test report, but it is recommended to use `show`.
<!-- Please provide some short description here -->

<!-- Please provide additional description with this PR. If there are any related issues, please link them here too. -->

### State of this PR
Ready for review

<!-- If there is any work left (see above) or things to consider -->

### Additional Context

`recheck diff GM1 GM2` → `recheck.result`

<!-- Add any other context, screenshots or minimal code example about the feature request here. Please check that you do not expose any secrets. -->