### PR TITLE
Release/v1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.retest</groupId>
 	<artifactId>recheck.cli</artifactId>
-	<version>1.9.0</version>
+	<version>1.10.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>recheck.cli</name>
@@ -60,7 +60,7 @@
 		<url>https://github.com/retest/recheck.cli</url>
 		<connection>scm:git:git@github.com:retest/recheck.cli.git</connection>
 		<developerConnection>scm:git:git@github.com:retest/recheck.cli.git</developerConnection>
-		<tag>v1.9.0</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<distributionManagement>


### PR DESCRIPTION
I think mergify failed with #201. It did merge the branch too early, without the changelog being adapted. As a result it did not delete the branch properly, as there were still some changes left to be merged. We should keep an eye on that.