### PR TITLE
Add usage subsections to print out

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,21 @@ As of now, `recheck` will give you the following help message:
 ```
 $ recheck
 Usage: recheck [--help] [--version] [COMMAND]
+
+Description:
 Command-line interface for recheck.
+
+Options:
       --help      Display this help message.
       --version   Display version info.
 Commands:
-  version     Display version info.
-  diff        Compare two Golden Masters.
-  show        Display differences of given test report.
+  help        Displays help information about the specified command
   commit      Accept specified differences of given test report.
-  ignore      Ignore specified differences of given test report.
   completion  Generate and display an auto completion script.
-  help        Displays help information about the specified command.
+  diff        Compare two Golden Masters.
+  ignore      Ignore specified differences of given test report.
+  show        Display differences of given test report.
+  version     Display version info.
 ```
 
 ## Setup

--- a/src/main/java/de/retest/recheck/cli/RecheckCli.java
+++ b/src/main/java/de/retest/recheck/cli/RecheckCli.java
@@ -15,9 +15,19 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 // TODO Add Migrate command when https://github.com/retest/recheck.cli/issues/85#issuecomment-526102137 is addressed.
-@Command( name = "recheck", description = "Command-line interface for recheck.",
-		versionProvider = VersionProvider.class, subcommands = { Version.class, Show.class, Diff.class, Commit.class,
-				Ignore.class, Completion.class, CommandLine.HelpCommand.class, Account.class } )
+@Command( name = "recheck", //
+		description = "Command-line interface for recheck.", //
+		versionProvider = VersionProvider.class, //
+		subcommands = { //
+				Account.class, //
+				CommandLine.HelpCommand.class, //
+				Commit.class, //
+				Completion.class, //
+				Diff.class, //
+				Ignore.class, //
+				Show.class, //
+				Version.class, //
+		} )
 public class RecheckCli implements Runnable {
 
 	private static final CommandLine.Help.ColorScheme colorScheme = new CommandLine.Help.ColorScheme.Builder() //
@@ -55,5 +65,4 @@ public class RecheckCli implements Runnable {
 				.setColorScheme( colorScheme ) //
 				.execute( args );
 	}
-
 }

--- a/src/main/java/de/retest/recheck/cli/subcommands/Account.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Account.java
@@ -7,8 +7,16 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
-@Command( name = "account", description = "Allows to log into and out of your account and show your API key.",
-		subcommands = { Login.class, Logout.class, Show.class } )
+@Command( name = "account", //
+		descriptionHeading = "%nDescription:%n", //
+		parameterListHeading = "%nParameters:%n", //
+		optionListHeading = "%nOptions:%n", // 
+		description = "Allows to log into and out of your account and show your API key.", //
+		subcommands = { //
+				Login.class, //
+				Logout.class, //
+				Show.class //
+		} )
 public class Account implements Runnable {
 
 	@Option( names = "--help", usageHelp = true, hidden = true )

--- a/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
@@ -35,7 +35,11 @@ import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command( name = "commit", description = "Accept specified differences of given test report." )
+@Command( name = "commit", //
+		descriptionHeading = "%nDescription:%n", //
+		parameterListHeading = "%nParameters:%n", //
+		optionListHeading = "%nOptions:%n", // 
+		description = "Accept specified differences of given test report." )
 public class Commit implements Runnable, IExitCodeGenerator {
 
 	private static final Logger logger = LoggerFactory.getLogger( Commit.class );

--- a/src/main/java/de/retest/recheck/cli/subcommands/Completion.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Completion.java
@@ -14,7 +14,11 @@ import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
 
-@Command( name = "completion", description = "Generate and display an auto completion script." )
+@Command( name = "completion", //
+		descriptionHeading = "%nDescription:%n", //
+		parameterListHeading = "%nParameters:%n", //
+		optionListHeading = "%nOptions:%n", //
+		description = "Generate and display an auto completion script." )
 public class Completion implements Runnable, IExitCodeGenerator {
 
 	private static final Logger logger = LoggerFactory.getLogger( Completion.class );

--- a/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
@@ -36,9 +36,12 @@ import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command( name = "diff", description = "Compare two Golden Masters." )
+@Command( name = "diff", //
+		descriptionHeading = "%nDescription:%n", //
+		parameterListHeading = "%nParameters:%n", //
+		optionListHeading = "%nOptions:%n", // 
+		description = "Compare two Golden Masters." )
 public class Diff implements Runnable, IExitCodeGenerator {
-
 	private static final Logger logger = LoggerFactory.getLogger( Diff.class );
 
 	private static final PersistenceFactory persistenceFactory = new PersistenceFactory( getXmlTransformer() );

--- a/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Ignore.java
@@ -32,9 +32,12 @@ import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command( name = "ignore", description = "Ignore specified differences of given test report." )
+@Command( name = "ignore", //
+		descriptionHeading = "%nDescription:%n", //
+		parameterListHeading = "%nParameters:%n", //
+		optionListHeading = "%nOptions:%n", //
+		description = "Ignore specified differences of given test report." )
 public class Ignore implements Runnable, IExitCodeGenerator {
-
 	private static final Logger logger = LoggerFactory.getLogger( Ignore.class );
 
 	@Option( names = "--help", usageHelp = true, hidden = true )

--- a/src/main/java/de/retest/recheck/cli/subcommands/Migrate.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Migrate.java
@@ -31,7 +31,11 @@ import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command( name = "migrate", description = "Migrate Golden Master(s)." )
+@Command( name = "migrate", //
+		descriptionHeading = "%nDescription:%n", //
+		parameterListHeading = "%nParameters:%n", //
+		optionListHeading = "%nOptions:%n", // 
+		description = "Migrate Golden Master(s)." )
 public class Migrate implements Runnable, IExitCodeGenerator {
 
 	private static final String RECHECK_FOLDER = "/src/test/resources/retest/recheck";

--- a/src/main/java/de/retest/recheck/cli/subcommands/Show.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Show.java
@@ -25,7 +25,11 @@ import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command( name = "show", description = "Display differences of given test report." )
+@Command( name = "show", //
+		descriptionHeading = "%nDescription:%n", //
+		parameterListHeading = "%nParameters:%n", //
+		optionListHeading = "%nOptions:%n", // 
+		description = "Display differences of given test report." )
 public class Show implements Runnable, IExitCodeGenerator {
 
 	private static final Logger logger = LoggerFactory.getLogger( Show.class );

--- a/src/main/java/de/retest/recheck/cli/subcommands/Version.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Version.java
@@ -7,7 +7,11 @@ import de.retest.recheck.cli.VersionProvider;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
-@Command( name = "version", description = Version.VERSION_CMD_DESCRIPTION )
+@Command( name = "version", //
+		descriptionHeading = "%nDescription:%n", //
+		parameterListHeading = "%nParameters:%n", //
+		optionListHeading = "%nOptions:%n", //
+		description = Version.VERSION_CMD_DESCRIPTION )
 public class Version implements Runnable {
 
 	public static final String VERSION_CMD_DESCRIPTION = "Display version info.";

--- a/src/main/java/de/retest/recheck/cli/subcommands/account/Login.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/account/Login.java
@@ -3,7 +3,11 @@ package de.retest.recheck.cli.subcommands.account;
 import de.retest.recheck.Rehub;
 import picocli.CommandLine.Command;
 
-@Command( name = "login", description = "Allows to log into your account." )
+@Command( name = "login", //
+		descriptionHeading = "%nDescription:%n", //
+		parameterListHeading = "%nParameters:%n", //
+		optionListHeading = "%nOptions:%n", //
+		description = "Allows to log into your account." )
 public class Login implements Runnable {
 
 	@Override

--- a/src/main/java/de/retest/recheck/cli/subcommands/account/Logout.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/account/Logout.java
@@ -10,7 +10,11 @@ import de.retest.recheck.Rehub;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IExitCodeGenerator;
 
-@Command( name = "logout", description = "Allows to log out of your account." )
+@Command( name = "logout", //
+		descriptionHeading = "%nDescription:%n", //
+		parameterListHeading = "%nParameters:%n", //
+		optionListHeading = "%nOptions:%n", //
+		description = "Allows to log out of your account." )
 public class Logout implements Runnable, IExitCodeGenerator {
 
 	private static final Logger logger = LoggerFactory.getLogger( Logout.class );
@@ -28,7 +32,8 @@ public class Logout implements Runnable, IExitCodeGenerator {
 		}
 	}
 
-	@Override public int getExitCode() {
+	@Override
+	public int getExitCode() {
 		return exitCode;
 	}
 }

--- a/src/main/java/de/retest/recheck/cli/subcommands/account/Show.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/account/Show.java
@@ -10,8 +10,13 @@ import de.retest.recheck.Rehub;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IExitCodeGenerator;
 
-@Command( name = "show", description = "Show your token e.g. for CI usage." )
+@Command( name = "show", //
+		descriptionHeading = "%nDescription:%n", //
+		parameterListHeading = "%nParameters:%n", //
+		optionListHeading = "%nOptions:%n", //
+		description = "Show your token e.g. for CI usage." )
 public class Show implements Runnable, IExitCodeGenerator {
+
 	private static final Logger logger = LoggerFactory.getLogger( Show.class );
 
 	private int exitCode = OK;

--- a/src/test/java/de/retest/recheck/cli/subcommands/CommitIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/CommitIT.java
@@ -33,12 +33,16 @@ public class CommitIT {
 
 	@Test
 	public void commit_without_argument_should_return_the_usage_message() {
-		final String expectedMessage = "Usage: commit [--all] [--exclude=<exclude>]... <testReport>\n"
-				+ "Accept specified differences of given test report.\n"
+		final String expectedMessage = "Usage: commit [--all] [--exclude=<exclude>]... <testReport>\n" //
+				+ "\n" //
+				+ "Description:\n" //
+				+ "Accept specified differences of given test report.\n" //
+				+ "\nParameters:\n" //
 				+ "      <testReport>          Path to a test report file (.report extension). If\n"
 				+ "                              the test report is not in the project directory,\n"
 				+ "                              please specify the absolute path, otherwise a\n"
-				+ "                              relative path is sufficient.\n"
+				+ "                              relative path is sufficient.\n" //
+				+ "\nOptions:\n" //
 				+ "      --all                 Accept all differences from the given test report.\n"
 				+ "      --exclude=<exclude>   Filter to exclude changes from the report. For a\n"
 				+ "                              custom filter, please specify the absolute path.\n"

--- a/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
@@ -30,18 +30,22 @@ public class DiffIT {
 
 	@Test
 	public void diff_without_argument_should_return_the_usage_message() {
-		final String expected = "Usage: diff [--output=<directory>] [--exclude=<exclude>]...\n"
-				+ "            <goldenMasterPath>..." + "Compare two Golden Masters.\n"
-				+ "      <goldenMasterPath>...  Path to a golden master folder. This command may\n"
-				+ "                               also be used with a single parameter to print\n"
-				+ "                               out a test report (deprecated).\n"
-				+ "      --exclude=<exclude>    Filter to exclude changes from the report. For a\n"
-				+ "                               custom filter, please specify the absolute path.\n"
-				+ "                               For predefined filters, a relative path is\n"
-				+ "                               sufficient. Specify this option multiple times\n"
-				+ "                               to use more than one filter.\n"
-				+ "      --output=<directory>   Save differences of Golden Masters to specified\n"
-				+ "                               directory as test report.\n";
+		final String expected =
+				"Usage: diff [--output=<directory>] [--exclude=<exclude>]...\n" + "            <goldenMasterPath>..." //
+						+ "\nDescription:\n" //
+						+ "Compare two Golden Masters.\n" //
+						+ "\nParameters:\n" //
+						+ "      <goldenMasterPath>...  Path to a golden master folder. This command may\n"
+						+ "                               also be used with a single parameter to print\n"
+						+ "                               out a test report (deprecated).\n" //
+						+ "\nOptions:\n" //
+						+ "      --exclude=<exclude>    Filter to exclude changes from the report. For a\n"
+						+ "                               custom filter, please specify the absolute path.\n"
+						+ "                               For predefined filters, a relative path is\n"
+						+ "                               sufficient. Specify this option multiple times\n"
+						+ "                               to use more than one filter.\n"
+						+ "      --output=<directory>   Save differences of Golden Masters to specified\n"
+						+ "                               directory as test report.\n";
 
 		assertThat( new CommandLine( new Diff() ).getUsageMessage() ).isEqualToIgnoringNewLines( expected );
 	}

--- a/src/test/java/de/retest/recheck/cli/subcommands/IgnoreIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/IgnoreIT.java
@@ -30,12 +30,14 @@ public class IgnoreIT {
 
 	@Test
 	public void ignore_without_argument_should_return_the_usage_message() {
-		final String expected = "Usage: ignore [--all] [--list] [<testReport>]\n"
-				+ "Ignore specified differences of given test report.\n"
+		final String expected = "Usage: ignore [--all] [--list] [<testReport>]\n" //
+				+ "\nDescription:\n" //
+				+ "Ignore specified differences of given test report.\n" //
+				+ "\nParameters:\n" //
 				+ "      [<testReport>]   Path to a test report file (.report extension). If the\n"
 				+ "                         test report is not in the project directory, please\n"
 				+ "                         specify the absolute path, otherwise a relative path\n"
-				+ "                         is sufficient.\n"
+				+ "                         is sufficient.\n" + "\nOptions:\n"
 				+ "      --all            Ignore all differences from the given test report.\n"
 				+ "      --list           List all ignored elements.";
 		assertThat( new CommandLine( new Ignore() ).getUsageMessage() ).isEqualToIgnoringNewLines( expected );

--- a/src/test/java/de/retest/recheck/cli/subcommands/ShowIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/ShowIT.java
@@ -28,17 +28,20 @@ public class ShowIT {
 
 	@Test
 	public void show_without_argument_should_return_the_usage_message() {
-		final String expected =
-				"Usage: show [--exclude=<exclude>]... <testReport>\n" + "Display differences of given test report.\n"
-						+ "      <testReport>          Path to a test report file (.report extension). If\n"
-						+ "                              the test report is not in the project directory,\n"
-						+ "                              please specify the absolute path, otherwise a\n"
-						+ "                              relative path is sufficient.\n"
-						+ "      --exclude=<exclude>   Filter to exclude changes from the report. For a\n"
-						+ "                              custom filter, please specify the absolute path.\n"
-						+ "                              For predefined filters, a relative path is\n"
-						+ "                              sufficient. Specify this option multiple times to\n"
-						+ "                              use more than one filter.\n";
+		final String expected = "Usage: show [--exclude=<exclude>]... <testReport>\n" //
+				+ "\nDescription:\n" //
+				+ "Display differences of given test report.\n" //
+				+ "\nParameters:\n" //
+				+ "      <testReport>          Path to a test report file (.report extension). If\n"
+				+ "                              the test report is not in the project directory,\n"
+				+ "                              please specify the absolute path, otherwise a\n"
+				+ "                              relative path is sufficient.\n" //
+				+ "\nOptions:\n" //
+				+ "      --exclude=<exclude>   Filter to exclude changes from the report. For a\n"
+				+ "                              custom filter, please specify the absolute path.\n"
+				+ "                              For predefined filters, a relative path is\n"
+				+ "                              sufficient. Specify this option multiple times to\n"
+				+ "                              use more than one filter.\n";
 		assertThat( new CommandLine( new Show() ).getUsageMessage() ).isEqualToIgnoringNewLines( expected );
 	}
 


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [ ] <s>you updated the changelog.</s>
- [ ] <s>you updated necessary documentation within [retest/docs](https://github.com/retest/docs).</s> Will update after approval (usage message examples in documentation)

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> <s>Enable ANSI colors on Windows, </s>Add subheadings to usage message <!-- Please provide some short description here -->

<!-- Please provide additional description with this PR. If there are any related issues, please link them here too. -->

Adds subheadings to usage message for clarity/improved readability.

### State of this PR

### Additional Context

<!-- Add any other context, screenshots or minimal code example about the feature request here. Please check that you do not expose any secrets. -->