### PR TITLE
Fix filtering in Show.java

### DIFF
--- a/src/main/java/de/retest/recheck/cli/subcommands/Show.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Show.java
@@ -16,7 +16,6 @@ import de.retest.recheck.cli.TestReportFormatException;
 import de.retest.recheck.cli.utils.ErrorHandler;
 import de.retest.recheck.cli.utils.FilterUtil;
 import de.retest.recheck.cli.utils.TestReportUtil;
-import de.retest.recheck.ignore.CompoundFilter;
 import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.printer.TestReportPrinter;
 import de.retest.recheck.report.TestReport;
@@ -65,8 +64,7 @@ public class Show implements Runnable, IExitCodeGenerator {
 	private void printDiff() throws TestReportFormatException, IOException {
 		final TestReport report = TestReportUtil.load( testReport );
 		final Filter excludeFilter = FilterUtil.getExcludeFilterFiles( exclude );
-		final Filter recheckIgnore = FilterUtil.loadRecheckIgnore();
-		final TestReportFilter filter = new TestReportFilter( new CompoundFilter( excludeFilter, recheckIgnore ) );
+		final TestReportFilter filter = new TestReportFilter( excludeFilter );
 		final TestReport filteredTestReport = filter.filter( report );
 		final TestReportPrinter printer = new TestReportPrinter( none() );
 


### PR DESCRIPTION

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [ ] <s>you updated the changelog.</s>
- [ ] <s>you updated necessary documentation within [retest/docs](https://github.com/retest/docs).</s>

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> Remove unnecessary loadRecheckIgnore() <!-- Please provide some short description here -->

`FilterUtil::getExcludeFilterFiles` is designed to either return the result of `loadRecheckIgnore()` or a `CompoundFilter` comprising `loadRecheckIgnore()` and `exclude` filters.
Thus it is unnecessary to have another call to `loadRecheckIgnore()` and create another `CompoundFilter`.

This change will remove duplicate print outs to the console such as

```
Specified JS filter file /var/folders/76/9l_0xdgn2cb3ygptp18g2d0c0000gp/T/junit5296205063854066511/.retest/recheck.ignore.js has no 'matches' function.
Specified JS filter file /var/folders/76/9l_0xdgn2cb3ygptp18g2d0c0000gp/T/junit5296205063854066511/.retest/recheck.ignore.js has no 'matches' function.
```

### State of this PR

done

### Additional Context
