### PR TITLE
Enable Ansi on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This command may still be used to show results of a test report. But it is advis
 
 * Do not print stack trace when a report is in an incompatible version.
 * Exit with a non-zero return code when a sub-command encounters a problem.
+* Enable ANSI on Windows and apply custom color scheme to usage messages.
 
 --------------------------------------------------------------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.fusesource.jansi</groupId>
+			<artifactId>jansi</artifactId>
+			<version>1.18</version>
+		</dependency>
+
+		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<version>1.2.3</version>

--- a/src/main/java/de/retest/recheck/cli/RecheckCli.java
+++ b/src/main/java/de/retest/recheck/cli/RecheckCli.java
@@ -1,11 +1,14 @@
 package de.retest.recheck.cli;
 
+import org.apache.commons.lang3.SystemUtils;
+import org.fusesource.jansi.AnsiConsole;
+
 import de.retest.recheck.cli.subcommands.Account;
 import de.retest.recheck.cli.subcommands.Commit;
 import de.retest.recheck.cli.subcommands.Completion;
-import de.retest.recheck.cli.subcommands.Show;
 import de.retest.recheck.cli.subcommands.Diff;
 import de.retest.recheck.cli.subcommands.Ignore;
+import de.retest.recheck.cli.subcommands.Show;
 import de.retest.recheck.cli.subcommands.Version;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -15,8 +18,12 @@ import picocli.CommandLine.Option;
 @Command( name = "recheck", description = "Command-line interface for recheck.",
 		versionProvider = VersionProvider.class, subcommands = { Version.class, Show.class, Diff.class, Commit.class,
 				Ignore.class, Completion.class, CommandLine.HelpCommand.class, Account.class } )
-
 public class RecheckCli implements Runnable {
+
+	private static final CommandLine.Help.ColorScheme colorScheme = new CommandLine.Help.ColorScheme.Builder() //
+			.commands( CommandLine.Help.Ansi.Style.fg_green ) //
+			.parameters( CommandLine.Help.Ansi.Style.fg_yellow ) //
+			.build();
 
 	@Option( names = "--help", usageHelp = true, description = "Display this help message." )
 	private boolean displayHelp;
@@ -26,12 +33,27 @@ public class RecheckCli implements Runnable {
 
 	@Override
 	public void run() {
-		CommandLine.usage( this, System.out );
+		CommandLine.usage( this, System.out, colorScheme );
 	}
 
 	public static void main( final String[] args ) {
-		final int exitCode = new CommandLine( new RecheckCli() ).execute( args );
+		final int exitCode;
+
+		if ( SystemUtils.IS_OS_WINDOWS ) {
+			AnsiConsole.systemInstall(); // enable colors on Windows
+			exitCode = createCommandLine( args );
+			AnsiConsole.systemUninstall(); // clean-up
+		} else {
+			exitCode = createCommandLine( args );
+		}
 		System.exit( exitCode );
+	}
+
+	private static int createCommandLine( final String[] args ) {
+		return new CommandLine( new RecheckCli() ) //
+				.setUsageHelpAutoWidth( true ) //
+				.setColorScheme( colorScheme ) //
+				.execute( args );
 	}
 
 }


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] <s>you updated necessary documentation within [retest/docs](https://github.com/retest/docs).</s>

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> Enables ANSI on Windows, adds custom color scheme to usage messages <!-- Please provide some short description here -->

<!-- Please provide additional description with this PR. If there are any related issues, please link them here too. -->

### State of this PR
 done
<!-- If there is any work left (see above) or things to consider -->

### Additional Context

https://github.com/retest/recheck.cli/pull/209#pullrequestreview-363030771