### PR TITLE
Rename method to more appropriate getFilterFiles()

### DIFF
--- a/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Commit.java
@@ -75,7 +75,7 @@ public class Commit implements Runnable, IExitCodeGenerator {
 				exitCode = SOFTWARE;
 			} else {
 				final TestReport report = TestReportUtil.load( testReport );
-				final TestReportFilter filter = new TestReportFilter( FilterUtil.getExcludeFilterFiles( exclude ) );
+				final TestReportFilter filter = new TestReportFilter( FilterUtil.getFilterFiles( exclude ) );
 				final TestReport filteredTestReport = filter.filter( report );
 				if ( !filteredTestReport.containsChanges() ) {
 					logger.warn( "The test report has no differences." );

--- a/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
@@ -148,8 +148,8 @@ public class Diff implements Runnable, IExitCodeGenerator {
 	}
 
 	private ActionReplayResult filterActionReplayResult( final ActionReplayResult actionReplayResult ) {
-		final Filter excludeFilter = FilterUtil.getExcludeFilterFiles( exclude );
-		final TestReportFilter reportFilter = new TestReportFilter( (excludeFilter) );
+		final Filter filterFiles = FilterUtil.getFilterFiles( exclude );
+		final TestReportFilter reportFilter = new TestReportFilter( (filterFiles) );
 		return reportFilter.filter( actionReplayResult );
 	}
 

--- a/src/main/java/de/retest/recheck/cli/subcommands/Show.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Show.java
@@ -67,8 +67,8 @@ public class Show implements Runnable, IExitCodeGenerator {
 
 	private void printDiff() throws TestReportFormatException, IOException {
 		final TestReport report = TestReportUtil.load( testReport );
-		final Filter excludeFilter = FilterUtil.getExcludeFilterFiles( exclude );
-		final TestReportFilter filter = new TestReportFilter( excludeFilter );
+		final Filter filterFiles = FilterUtil.getFilterFiles( exclude );
+		final TestReportFilter filter = new TestReportFilter( filterFiles );
 		final TestReport filteredTestReport = filter.filter( report );
 		final TestReportPrinter printer = new TestReportPrinter( none() );
 

--- a/src/main/java/de/retest/recheck/cli/utils/FilterUtil.java
+++ b/src/main/java/de/retest/recheck/cli/utils/FilterUtil.java
@@ -26,7 +26,7 @@ public class FilterUtil {
 
 	private FilterUtil() {}
 
-	public static Filter getExcludeFilterFiles( final List<String> exclude ) {
+	public static Filter getFilterFiles( final List<String> exclude ) {
 		if ( exclude == null ) {
 			return loadRecheckIgnore();
 		}

--- a/src/test/java/de/retest/recheck/cli/utils/FilterUtilTest.java
+++ b/src/test/java/de/retest/recheck/cli/utils/FilterUtilTest.java
@@ -18,7 +18,7 @@ class FilterUtilTest {
 	@Test
 	void when_exclude_is_not_empty_the_filters_plus_GlobalIgnoreApplier_should_be_returned() throws IOException {
 		final List<String> exclude = Arrays.asList( "positioning.filter" );
-		final CompoundFilter filter = (CompoundFilter) FilterUtil.getExcludeFilterFiles( exclude );
+		final CompoundFilter filter = (CompoundFilter) FilterUtil.getFilterFiles( exclude );
 		// +1 for GlobalIgnoreApplier.
 		assertThat( filter.getFilters() ).hasSize( exclude.size() + 1 );
 	}
@@ -26,14 +26,14 @@ class FilterUtilTest {
 	@Test
 	void when_exclude_is_empty_only_GlobalIgnoreApplier_should_be_returned() throws IOException {
 		final List<String> exclude = Collections.emptyList();
-		final CompoundFilter filter = (CompoundFilter) FilterUtil.getExcludeFilterFiles( exclude );
+		final CompoundFilter filter = (CompoundFilter) FilterUtil.getFilterFiles( exclude );
 		// +1 for GlobalIgnoreApplier.
 		assertThat( filter.getFilters() ).hasSize( 1 );
 	}
 
 	@Test
 	void when_exclude_is_null_recheck_ignore_should_be_returned() throws Exception {
-		final Filter filter = FilterUtil.getExcludeFilterFiles( null );
+		final Filter filter = FilterUtil.getFilterFiles( null );
 		assertThat( filter ).isInstanceOf( GlobalIgnoreApplier.class );
 	}
 


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [ ] <s>you updated the changelog.</s>
- [ ] <s>you updated necessary documentation within [retest/docs](https://github.com/retest/docs).</s>

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> Change to more appropriate method name <!-- Please provide some short description here -->

Since the method does not only return filters listed in the exclude options, it would be more appropriate to change the method name to `getFilterFiles(...)`.
<!-- Please provide additional description with this PR. If there are any related issues, please link them here too. -->

### State of this PR

<!-- If there is any work left (see above) or things to consider -->

### Additional Context
see #214
<!-- Add any other context, screenshots or minimal code example about the feature request here. Please check that you do not expose any secrets. -->