### PR TITLE
Fix/update recheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<maven.surefire.and.failsafe.version>2.22.2</maven.surefire.and.failsafe.version>
 		<junit.jupiter.version>5.6.0</junit.jupiter.version>
 		<junit.vintage.version>5.6.0</junit.vintage.version>
-		<recheck.version>1.10.0-beta.1</recheck.version>
+		<recheck.version>1.10.0-beta.2</recheck.version>
 	</properties>
 
 	<scm>

--- a/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
@@ -119,8 +119,10 @@ public class DiffIT {
 				+ "\t  Please note that these differences do not affect the result and are not included in the difference count.\n"
 				+ "\t\tsome.driver:\n" // 
 				+ "\t\t  expected=\"driverA\",\n" // 
-				+ "\t\t    actual=\"driverB\"\n" + "\tbaz [changed text] at 'foo[1]/bar[1]/baz[1]':\n" // 
-				+ "\t\twas deleted\n" + "\tbaz [original text] at 'foo[1]/bar[1]/baz[1]':\n" // 
+				+ "\t\t    actual=\"driverB\"\n" // 
+				+ "\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" // 
+				+ "\t\twas deleted\n" // 
+				+ "\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" // 
 				+ "\t\twas inserted";
 
 		assertThat( systemOutRule.getLog() ).containsSubsequence( expected );
@@ -231,15 +233,15 @@ public class DiffIT {
 		final String expected = "Suite 'diff_should_print_differences' has 3 difference(s) in 1 test(s):\n" //
 				+ "\tTest 'test' has 3 difference(s) in 3 state(s):\n" //
 				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz [original text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
 				+ "\t\t\ttext:\n" //
 				+ "\t\t\t  expected=\"original text\",\n" //
 				+ "\t\t\t    actual=\"changed text\"\n" //
 				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz [original text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
 				+ "\t\t\twas deleted\n" //
 				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz [changed text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
 				+ "\t\t\twas inserted";
 
 		assertThat( systemOutRule.getLog() ).contains( expected );
@@ -257,15 +259,15 @@ public class DiffIT {
 
 		final String expected = "\tTest 'test' has 3 difference(s) in 3 state(s):\n" //
 				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz [original text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
 				+ "\t\t\ttext:\n" //
 				+ "\t\t\t  expected=\"original text\",\n" //
 				+ "\t\t\t    actual=\"changed text\"\n" //
 				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz [original text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
 				+ "\t\t\twas deleted\n" //
 				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz [changed text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
 				+ "\t\t\twas inserted";
 
 		assertThat( systemOutRule.getLog() ).contains( expected );

--- a/src/test/java/de/retest/recheck/cli/subcommands/ShowIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/ShowIT.java
@@ -56,15 +56,15 @@ public class ShowIT {
 		final String expected = "Suite 'diff_should_print_differences' has 3 difference(s) in 1 test(s):\n" //
 				+ "\tTest 'test' has 3 difference(s) in 3 state(s):\n" //
 				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz [original text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
 				+ "\t\t\ttext:\n" //
 				+ "\t\t\t  expected=\"original text\",\n" //
 				+ "\t\t\t    actual=\"changed text\"\n" //
 				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz [original text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
 				+ "\t\t\twas deleted\n" //
 				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz [changed text] at 'foo[1]/bar[1]/baz[1]':\n" //
+				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
 				+ "\t\t\twas inserted";
 
 		assertThat( systemOutRule.getLog() ).contains( expected );


### PR DESCRIPTION
The text was now changed to include `{$tag} (${retestID})` (see retest/recheck#667)