### PR TITLE
Inform user of used filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Table of Contents
 
 ### Improvements
 
+* When using the exclude option, the user will be informed which filter (e.g. from project or user folder) is applied to the report results.
+
 
 --------------------------------------------------------------------------------
 

--- a/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
@@ -150,6 +150,7 @@ public class Diff implements Runnable, IExitCodeGenerator {
 	private ActionReplayResult filterActionReplayResult( final ActionReplayResult actionReplayResult ) {
 		final Filter filterFiles = FilterUtil.getFilterFiles( exclude );
 		final TestReportFilter reportFilter = new TestReportFilter( (filterFiles) );
+		FilterUtil.printUsedFilterPaths( filterFiles );
 		return reportFilter.filter( actionReplayResult );
 	}
 

--- a/src/main/java/de/retest/recheck/cli/subcommands/Show.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Show.java
@@ -73,6 +73,9 @@ public class Show implements Runnable, IExitCodeGenerator {
 		final TestReport report = TestReportUtil.load( testReport );
 		final Filter filterFiles = FilterUtil.getFilterFiles( exclude );
 		final TestReportFilter filter = new TestReportFilter( filterFiles );
+
+		FilterUtil.printUsedFilterPaths( filterFiles );
+
 		final TestReport filteredTestReport = filter.filter( report );
 		final TestReportPrinter printer = new TestReportPrinter( none() );
 

--- a/src/main/java/de/retest/recheck/cli/utils/FilterUtil.java
+++ b/src/main/java/de/retest/recheck/cli/utils/FilterUtil.java
@@ -63,7 +63,7 @@ public class FilterUtil {
 		} catch ( final IOException e ) {
 			log.error( "Failed to load recheck.ignore.", e );
 		}
-		return Filter.FILTER_NOTHING;
+		return Filter.NEVER_MATCH;
 	}
 
 	public static boolean hasValidExcludeOption( final List<String> exclude ) {

--- a/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
@@ -221,6 +221,32 @@ public class DiffIT {
 				.contains( "The invalid filter files are: sty-attributes.filter, invisib.filter" );
 	}
 
+	@Test
+	public void diff_should_print_used_filters_with_correct_exclude_options() throws IOException {
+		temp.newFolder( "path" );
+		temp.newFolder( "path", "goldenmaster" );
+		temp.newFolder( "someotherpath" );
+		temp.newFolder( "someotherpath", "goldenmaster" );
+
+		final File outputDir = temp.newFolder( "somedirectory" );
+
+		final File gm1 = temp.newFolder( "path", "goldenmaster", "a" );
+		final File gm2 = temp.newFolder( "someotherpath", "goldenmaster", "b" );
+
+		GoldenMasterCreator.createGoldenMasterFile( gm1, true );
+		GoldenMasterCreator.createGoldenMasterFile( gm2, false );
+
+		final String[] args = { "--exclude", "style-attributes.filter", "--output", outputDir.getAbsolutePath(),
+				gm1.getAbsolutePath(), gm2.getAbsolutePath() };
+
+		new CommandLine( new Diff() ).execute( args );
+
+		final String expected = "The following filter files have been applied:\n" //
+				+ "\t/filter/web/style-attributes.filter";
+
+		assertThat( systemOutRule.getLog() ).contains( expected );
+	}
+
 	// remove this test in next version when old diff functionality is provided only under new command (see RET-1956)
 	@Test
 	public void diff_should_print_diff_of_test_report_if_used_with_single_parameter() throws IOException {

--- a/src/test/java/de/retest/recheck/cli/subcommands/ShowIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/ShowIT.java
@@ -3,6 +3,7 @@ package de.retest.recheck.cli.subcommands;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -90,5 +91,20 @@ public class ShowIT {
 
 		assertThat( systemOutRule.getLog() ).contains( "The given file report '" + doesNotExist.getAbsolutePath()
 				+ "' does not exist. Please check the given file path." );
+	}
+
+	@Test
+	public void show_should_print_used_filters_with_correct_exclude_options() throws IOException {
+		ProjectRootFaker.fakeProjectRoot( temp.getRoot().toPath() );
+		final String[] args = { "--exclude", "invisible-attributes.filter", "--exclude", "positioning.filter",
+				TestReportCreator.createTestReportFileWithDiffs( temp ) };
+
+		new CommandLine( new Show() ).execute( args );
+
+		final String expected = "The following filter files have been applied:\n" //
+				+ "\t/filter/web/positioning.filter\n" //
+				+ "\t/filter/web/invisible-attributes.filter";
+
+		assertThat( systemOutRule.getLog() ).contains( expected );
 	}
 }


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] <s>you updated necessary documentation within [retest/docs](https://github.com/retest/docs).</s>

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> Display applied filter(s)<!-- Please provide some short description here -->

When using the exlude option, the user should be informed which filters are applied in the end (e.g. if filter from project folder, user folder).

### State of this PR

Ready for review
<!-- If there is any work left (see above) or things to consider -->

### Additional Context

https://docs.retest.de/recheck/usage/filter/