### PR TITLE
Remove deprecated use for diff command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Table of Contents
 
 ### Breaking Changes
 
+* `diff` command can no longer be used to display a test report. Use `show` instead.
+
 ### Bug Fixes
 
 ### New Features

--- a/src/main/java/de/retest/recheck/cli/utils/GoldenMasterUtil.java
+++ b/src/main/java/de/retest/recheck/cli/utils/GoldenMasterUtil.java
@@ -2,9 +2,7 @@ package de.retest.recheck.cli.utils;
 
 public class GoldenMasterUtil {
 
-	public static final String GOLDEN_MASTER_PARAMETER_DESCRIPTION =
-			"Path to a golden master folder. This command may also "
-					+ "be used with a single parameter to print out a test report (deprecated)."; //
+	public static final String GOLDEN_MASTER_PARAMETER_DESCRIPTION = "Path to a golden master folder."; //
 
 	private GoldenMasterUtil() {}
 

--- a/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
@@ -13,8 +13,6 @@ import org.junit.rules.TemporaryFolder;
 
 import de.retest.recheck.RecheckProperties;
 import de.retest.recheck.cli.testutils.GoldenMasterCreator;
-import de.retest.recheck.cli.testutils.ProjectRootFaker;
-import de.retest.recheck.cli.testutils.TestReportCreator;
 import de.retest.recheck.util.FileUtil;
 import picocli.CommandLine;
 
@@ -30,22 +28,21 @@ public class DiffIT {
 
 	@Test
 	public void diff_without_argument_should_return_the_usage_message() {
-		final String expected =
-				"Usage: diff [--output=<directory>] [--exclude=<exclude>]...\n" + "            <goldenMasterPath>..." //
-						+ "\nDescription:\n" //
-						+ "Compare two Golden Masters.\n" //
-						+ "\nParameters:\n" //
-						+ "      <goldenMasterPath>...  Path to a golden master folder. This command may\n"
-						+ "                               also be used with a single parameter to print\n"
-						+ "                               out a test report (deprecated).\n" //
-						+ "\nOptions:\n" //
-						+ "      --exclude=<exclude>    Filter to exclude changes from the report. For a\n"
-						+ "                               custom filter, please specify the absolute path.\n"
-						+ "                               For predefined filters, a relative path is\n"
-						+ "                               sufficient. Specify this option multiple times\n"
-						+ "                               to use more than one filter.\n"
-						+ "      --output=<directory>   Save differences of Golden Masters to specified\n"
-						+ "                               directory as test report.\n";
+		final String expected = "Usage: diff [--output=<directory>] [--exclude=<exclude>]... (<goldenMasterPath>\n" //
+				+ "            <goldenMasterPath>)..." //
+				+ "\nDescription:\n" //
+				+ "Compare two Golden Masters.\n" //
+				+ "\nParameters:\n" //
+				+ "      (<goldenMasterPath> <goldenMasterPath>)...\n"
+				+ "                             Path to a golden master folder." //
+				+ "\nOptions:\n" //
+				+ "      --exclude=<exclude>    Filter to exclude changes from the report. For a\n"
+				+ "                               custom filter, please specify the absolute path.\n"
+				+ "                               For predefined filters, a relative path is\n"
+				+ "                               sufficient. Specify this option multiple times\n"
+				+ "                               to use more than one filter.\n"
+				+ "      --output=<directory>   Save differences of Golden Masters to specified\n"
+				+ "                               directory as test report.\n";
 
 		assertThat( new CommandLine( new Diff() ).getUsageMessage() ).isEqualToIgnoringNewLines( expected );
 	}
@@ -243,58 +240,6 @@ public class DiffIT {
 
 		final String expected = "The following filter files have been applied:\n" //
 				+ "\t/filter/web/style-attributes.filter";
-
-		assertThat( systemOutRule.getLog() ).contains( expected );
-	}
-
-	// remove this test in next version when old diff functionality is provided only under new command (see RET-1956)
-	@Test
-	public void diff_should_print_diff_of_test_report_if_used_with_single_parameter() throws IOException {
-		ProjectRootFaker.fakeProjectRoot( temp.getRoot().toPath() );
-		final String[] args =
-				{ TestReportCreator.createTestReportFileWithDiffs( temp, "diff_should_print_differences" ) };
-
-		new CommandLine( new Diff() ).execute( args );
-
-		final String expected = "Suite 'diff_should_print_differences' has 3 difference(s) in 1 test(s):\n" //
-				+ "\tTest 'test' has 3 difference(s) in 3 state(s):\n" //
-				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
-				+ "\t\t\ttext:\n" //
-				+ "\t\t\t  expected=\"original text\",\n" //
-				+ "\t\t\t    actual=\"changed text\"\n" //
-				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
-				+ "\t\t\twas deleted\n" //
-				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
-				+ "\t\t\twas inserted";
-
-		assertThat( systemOutRule.getLog() ).contains( expected );
-	}
-
-	// remove this test in next version when old diff functionality is provided only under new command (see RET-1956)
-	@Test
-	public void diff_should_print_diff_of_test_report_if_used_with_single_parameter_and_exclude_option()
-			throws IOException {
-		ProjectRootFaker.fakeProjectRoot( temp.getRoot().toPath() );
-		final String[] args = { "--exclude", "invisible-attributes.filter", "--exclude", "positioning.filter",
-				TestReportCreator.createTestReportFileWithDiffs( temp ) };
-
-		new CommandLine( new Diff() ).execute( args );
-
-		final String expected = "\tTest 'test' has 3 difference(s) in 3 state(s):\n" //
-				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
-				+ "\t\t\ttext:\n" //
-				+ "\t\t\t  expected=\"original text\",\n" //
-				+ "\t\t\t    actual=\"changed text\"\n" //
-				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
-				+ "\t\t\twas deleted\n" //
-				+ "\tcheck resulted in:\n" //
-				+ "\t\tbaz (someTitle) at 'foo[1]/bar[1]/baz[1]':\n" //
-				+ "\t\t\twas inserted";
 
 		assertThat( systemOutRule.getLog() ).contains( expected );
 	}


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs). --> see https://github.com/retest/docs/pull/103

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> Remove deprecated use for `diff` command <!-- Please provide some short description here -->

### State of this PR

done

### Additional Context

RET-1956