### PR TITLE
Fix logger config

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
 		class="ch.qos.logback.core.ConsoleAppender">
 		<withJansi>true</withJansi>
 		<encoder>
-			<pattern>%-10(%highlight([%level])) %msg%n</pattern>
+			<pattern>%msg%n</pattern>
 		</encoder>
 	</appender>
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
 
 	<appender name="STDOUT"
-	          class="ch.qos.logback.core.ConsoleAppender">
+		class="ch.qos.logback.core.ConsoleAppender">
 		<withJansi>true</withJansi>
 		<encoder>
 			<pattern>%-10(%highlight([%level])) %msg%n</pattern>
@@ -9,7 +9,7 @@
 	</appender>
 
 	<root level="info">
-		<appender-ref ref="STDOUT"/>
+		<appender-ref ref="STDOUT" />
 	</root>
 
 </configuration>


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [ ] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [ ] you updated the changelog.
- [ ] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

## Description

The CLI shouldn't print the log level, I believe this is only confusing for the user. At least I cannot remember seeing this in another CLI? (Besides build tools such as Maven.)

What's your say on this? There is also a whole section on colors in Picocli: https://picocli.info/#_ansi_colors_and_styles