### PR TITLE
Used filter message should only appear when exclude option is used

### DIFF
--- a/src/main/java/de/retest/recheck/cli/utils/FilterUtil.java
+++ b/src/main/java/de/retest/recheck/cli/utils/FilterUtil.java
@@ -112,6 +112,8 @@ public class FilterUtil {
 				filterPathNames.append( p.toAbsolutePath().toString() );
 			}
 		} );
-		log.info( "The following filter files have been applied:{}", filterPathNames );
+		if ( filterPathNames.length() > 0 ) {
+			log.info( "The following filter files have been applied:{}", filterPathNames );
+		}
 	}
 }

--- a/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/DiffIT.java
@@ -244,4 +244,26 @@ public class DiffIT {
 		assertThat( systemOutRule.getLog() ).contains( expected );
 	}
 
+	@Test
+	public void diff_should_not_print_used_filter_message_without_exclude_options() throws IOException {
+		temp.newFolder( "path" );
+		temp.newFolder( "path", "goldenmaster" );
+		temp.newFolder( "someotherpath" );
+		temp.newFolder( "someotherpath", "goldenmaster" );
+
+		final File outputDir = temp.newFolder( "somedirectory" );
+
+		final File gm1 = temp.newFolder( "path", "goldenmaster", "a" );
+		final File gm2 = temp.newFolder( "someotherpath", "goldenmaster", "b" );
+
+		GoldenMasterCreator.createGoldenMasterFile( gm1, true );
+		GoldenMasterCreator.createGoldenMasterFile( gm2, false );
+
+		final String[] args = { outputDir.getAbsolutePath(), gm1.getAbsolutePath(), gm2.getAbsolutePath() };
+
+		new CommandLine( new Diff() ).execute( args );
+
+		assertThat( systemOutRule.getLog() ).doesNotContain( "The following filter files have been applied:" );
+	}
+
 }

--- a/src/test/java/de/retest/recheck/cli/subcommands/ShowIT.java
+++ b/src/test/java/de/retest/recheck/cli/subcommands/ShowIT.java
@@ -107,4 +107,14 @@ public class ShowIT {
 
 		assertThat( systemOutRule.getLog() ).contains( expected );
 	}
+
+	@Test
+	public void show_should_not_print_used_filter_message_without_exclude_options() throws IOException {
+		ProjectRootFaker.fakeProjectRoot( temp.getRoot().toPath() );
+		final String[] args = { TestReportCreator.createTestReportFileWithDiffs( temp ) };
+
+		new CommandLine( new Show() ).execute( args );
+
+		assertThat( systemOutRule.getLog() ).doesNotContain( "The following filter files have been applied:" );
+	}
 }


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [ ] <s>you updated the changelog.</s>
- [ ] <s>you updated necessary documentation within [retest/docs](https://github.com/retest/docs).</s>

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> Used filter message should only appear when exclude option is used <!-- Please provide some short description here -->

### State of this PR

done

### Additional Context
