### PR TITLE
Add highlighter for report difference print out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Table of Contents
 ### Improvements
 
 * When using the exclude option, the user will be informed which filter (e.g. from project or user folder) is applied to the report results.
-
+* Difference output that can be created with `show` or `diff` now includes colors to improve readability of the output.
 
 --------------------------------------------------------------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
 		<maven.surefire.and.failsafe.version>2.22.2</maven.surefire.and.failsafe.version>
 		<junit.jupiter.version>5.6.1</junit.jupiter.version>
 		<junit.vintage.version>5.6.1</junit.vintage.version>
-		<recheck.version>1.10.2</recheck.version>
 	</properties>
 
 	<scm>
@@ -90,7 +89,7 @@
 		<dependency>
 			<groupId>de.retest</groupId>
 			<artifactId>recheck</artifactId>
-			<version>${recheck.version}</version>
+			<version>-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Diff.java
@@ -17,6 +17,7 @@ import de.retest.recheck.SuiteAggregator;
 import de.retest.recheck.cli.utils.ErrorHandler;
 import de.retest.recheck.cli.utils.FilterUtil;
 import de.retest.recheck.cli.utils.GoldenMasterUtil;
+import de.retest.recheck.cli.utils.style.DifferenceHighlighter;
 import de.retest.recheck.execution.RecheckDifferenceFinder;
 import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.persistence.GoldenMasterProvider;
@@ -111,7 +112,7 @@ public class Diff implements Runnable, IExitCodeGenerator {
 
 	private void printGoldenMasterDifferences( final ActionReplayResult actionReplayResult ) {
 		final ActionReplayResultPrinter printer =
-				new ActionReplayResultPrinter( ( attributes, s, serializable ) -> false );
+				new ActionReplayResultPrinter( ( attributes, s, serializable ) -> false, new DifferenceHighlighter() );
 		logger.info( "\n\n{}\n\n", printer.toString( actionReplayResult ) );
 
 		final int differenceCount = actionReplayResult.getDifferences().size();

--- a/src/main/java/de/retest/recheck/cli/subcommands/Show.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Show.java
@@ -17,10 +17,13 @@ import de.retest.recheck.cli.TestReportFormatException;
 import de.retest.recheck.cli.utils.ErrorHandler;
 import de.retest.recheck.cli.utils.FilterUtil;
 import de.retest.recheck.cli.utils.TestReportUtil;
+import de.retest.recheck.cli.utils.style.DifferenceHighlighter;
 import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.printer.TestReportPrinter;
+import de.retest.recheck.printer.highlighting.GlobalHighlighter;
 import de.retest.recheck.report.TestReport;
 import de.retest.recheck.report.TestReportFilter;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
@@ -77,6 +80,10 @@ public class Show implements Runnable, IExitCodeGenerator {
 		FilterUtil.printUsedFilterPaths( filterFiles );
 
 		final TestReport filteredTestReport = filter.filter( report );
+
+		// replace DefaultHighlighter to get colorized output for differences
+		GlobalHighlighter.setHighlighter( new DifferenceHighlighter() );
+
 		final TestReportPrinter printer = new TestReportPrinter( none() );
 
 		logger.info( "\n\n{}\n\n", printer.toString( filteredTestReport ) );

--- a/src/main/java/de/retest/recheck/cli/subcommands/Show.java
+++ b/src/main/java/de/retest/recheck/cli/subcommands/Show.java
@@ -20,10 +20,8 @@ import de.retest.recheck.cli.utils.TestReportUtil;
 import de.retest.recheck.cli.utils.style.DifferenceHighlighter;
 import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.printer.TestReportPrinter;
-import de.retest.recheck.printer.highlighting.GlobalHighlighter;
 import de.retest.recheck.report.TestReport;
 import de.retest.recheck.report.TestReportFilter;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
@@ -81,10 +79,7 @@ public class Show implements Runnable, IExitCodeGenerator {
 
 		final TestReport filteredTestReport = filter.filter( report );
 
-		// replace DefaultHighlighter to get colorized output for differences
-		GlobalHighlighter.setHighlighter( new DifferenceHighlighter() );
-
-		final TestReportPrinter printer = new TestReportPrinter( none() );
+		final TestReportPrinter printer = new TestReportPrinter( none(), new DifferenceHighlighter() );
 
 		logger.info( "\n\n{}\n\n", printer.toString( filteredTestReport ) );
 

--- a/src/main/java/de/retest/recheck/cli/utils/style/DifferenceHighlighter.java
+++ b/src/main/java/de/retest/recheck/cli/utils/style/DifferenceHighlighter.java
@@ -1,0 +1,4 @@
+package de.retest.recheck.cli.utils.style;
+
+public class DifferenceHighlighter {
+}

--- a/src/main/java/de/retest/recheck/cli/utils/style/DifferenceHighlighter.java
+++ b/src/main/java/de/retest/recheck/cli/utils/style/DifferenceHighlighter.java
@@ -1,4 +1,56 @@
 package de.retest.recheck.cli.utils.style;
 
-public class DifferenceHighlighter {
+import de.retest.recheck.printer.highlighting.HighlightType;
+import de.retest.recheck.printer.highlighting.Highlighter;
+import de.retest.recheck.printer.highlighting.UnsupportedHighlightTypeException;
+import picocli.CommandLine;
+
+public class DifferenceHighlighter implements Highlighter {
+
+	@Override
+	public String highlight( final String msg, final HighlightType element ) {
+		switch ( element ) {
+			case KEY:
+			case TYPE:
+			case TESTREPLAYRESULT_NAME:
+				return retestGreen( msg );
+			case HEADING_SUITE_RESULTS:
+				return underline( bold( retestRed( msg ) ) );
+			case ELEMENT:
+				return retestRed( msg );
+			case HEADING_METADATA:
+				return bold( retestGreen( msg ) );
+			case VALUE_EXPECTED:
+			case VALUE_ACTUAL:
+			case ACTUAL:
+			case EXPECTED:
+				return msg;
+			case NOTE:
+			case PATH:
+				return faint( msg );
+			default:
+				throw new UnsupportedHighlightTypeException( "The provided element is not defined for highlighting." );
+		}
+	}
+
+	String retestGreen( final String msg ) {
+		return CommandLine.Help.Ansi.AUTO.string( "@|fg(46) " + msg + "|@" );
+	}
+
+	String retestRed( final String msg ) {
+		return CommandLine.Help.Ansi.AUTO.string( "@|fg(198) " + msg + "|@" );
+	}
+
+	String bold( final String msg ) {
+		return CommandLine.Help.Ansi.AUTO.string( "@|bold " + msg + "|@" );
+	}
+
+	String faint( final String msg ) {
+		return CommandLine.Help.Ansi.AUTO.string( "@|faint " + msg + "|@" );
+	}
+
+	String underline( final String msg ) {
+		return CommandLine.Help.Ansi.AUTO.string( "@|underline " + msg + "|@" );
+	}
+
 }


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [ ] <s>the necessary tests are either created or updated.</s>
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] <s>you updated necessary documentation within [retest/docs](https://github.com/retest/docs).</s>

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> Highlighter for difference output <!-- Please provide some short description here -->

The highlighter for certain keywords should provide a better readability of the difference output. My coloring proposal includes similar colors to the two main company colors (retest green, retest red) of Retest GmbH (see [https://assets.retest.org/retest/ci/colors.html)](https://assets.retest.org/retest/ci/colors.html)).

### State of this PR

Uses jitpack.io to build from latest commit in recheck repo.

### Additional Context

RET-2017